### PR TITLE
Disclosure pagination

### DIFF
--- a/fastquant/disclosures.py
+++ b/fastquant/disclosures.py
@@ -266,7 +266,7 @@ class DisclosuresPSE:
         first_page_df = self.get_company_disclosures_page(
             page=self.start_page
         )
-        print("{} pages detected!".format(page_count))
+        print("{} pages detected!".format(self.page_count))
         if self.page_count == 1:
             disclosures_df = first_page_df
         else:

--- a/fastquant/disclosures.py
+++ b/fastquant/disclosures.py
@@ -263,11 +263,11 @@ class DisclosuresPSE:
             Ending date of the disclosure data pull
         """
 
-        first_page_df, page_count = self.get_company_disclosures_page(
+        first_page_df = self.get_company_disclosures_page(
             page=self.start_page
         )
         print("{} pages detected!".format(page_count))
-        if page_count == 1:
+        if self.page_count == 1:
             disclosures_df = first_page_df
         else:
             page_dfs = [first_page_df]

--- a/fastquant/disclosures.py
+++ b/fastquant/disclosures.py
@@ -275,7 +275,7 @@ class DisclosuresPSE:
             for page_num in range(2, self.page_count + 1):
                 page_df = self.get_company_disclosures_page(page=page_num)
                 page_dfs.append(page_df)
-            pages_df = pd.concat(page_dfs)
+            pages_df = pd.concat(page_dfs).reset_index(drop=True)
             disclosures_df = pages_df
         return disclosures_df
 

--- a/fastquant/disclosures.py
+++ b/fastquant/disclosures.py
@@ -273,7 +273,7 @@ class DisclosuresPSE:
             page_dfs = [first_page_df]
             # We skip the first since we already have it
             for page_num in range(2, self.page_count + 1):
-                page_df = get_company_disclosures_page(self, page=page_num)
+                page_df = self.get_company_disclosures_page(page=page_num)
                 page_dfs.append(page_df)
             pages_df = pd.concat(page_dfs)
             disclosures_df = pages_df

--- a/fastquant/disclosures.py
+++ b/fastquant/disclosures.py
@@ -81,7 +81,6 @@ class DisclosuresPSE:
         self.symbol = symbol.upper()
         self.start_date = start_date
         self.end_date = TODAY if end_date is None else end_date
-        self.start_page = start_page
         self.disclosure_type = disclosure_type
         self.stock_data = None
         self.verbose = verbose
@@ -264,7 +263,7 @@ class DisclosuresPSE:
         """
 
         first_page_df = self.get_company_disclosures_page(
-            page=self.start_page
+            page=1
         )
         print("{} pages detected!".format(self.page_count))
         if self.page_count == 1:

--- a/fastquant/disclosures.py
+++ b/fastquant/disclosures.py
@@ -150,7 +150,7 @@ class DisclosuresPSE:
         self.stock_data = data
         return data
 
-    def get_company_disclosures_page(self, page=1, page_count=False):
+    def get_company_disclosures_page(self, page=1):
         """
         Gets company disclosures for one page
 
@@ -249,10 +249,7 @@ class DisclosuresPSE:
         df["Announce Date and Time"] = pd.to_datetime(
             df["Announce Date and Time"]
         )
-        if page_count:
-            return df, page_count
-        else:
-            return df
+        return df
 
     def get_company_disclosures(self):
         """
@@ -267,7 +264,7 @@ class DisclosuresPSE:
         """
 
         first_page_df, page_count = self.get_company_disclosures_page(
-            page=self.start_page, page_count=True
+            page=self.start_page
         )
         print("{} pages detected!".format(page_count))
         if page_count == 1:
@@ -275,7 +272,7 @@ class DisclosuresPSE:
         else:
             page_dfs = [first_page_df]
             # We skip the first since we already have it
-            for page_num in range(2, page_count + 1):
+            for page_num in range(2, self.page_count + 1):
                 page_df = get_company_disclosures_page(self, page=page_num)
                 page_dfs.append(page_df)
             pages_df = pd.concat(page_dfs)


### PR DESCRIPTION
@jpdeleon Multi page disclosure querying should work now, by identifying the number of pages in the results and looping through each of the pages.

Sampe code (2 pages):

```
DATE_START = "01-01-2018"
DATE_END = "12-01-2019"
cd = DisclosuresPSE(
    symbol=PHISIX_SYMBOL, start_date=DATE_START, end_date=DATE_END
)
cd.company_disclosures.shape
# (59, 7)
```