### PR TITLE
[ISSUES-85] Replace numpy argswhere with flatnonzero

### DIFF
--- a/fastquant/disclosures.py
+++ b/fastquant/disclosures.py
@@ -432,7 +432,7 @@ class DisclosuresPSE:
         older = (
             oldest_date > self.company_disclosures["Announce Date and Time"]
         )
-        idxs1 = np.argwhere(older).flatten()
+        idxs1 = np.flatnonzero(older)
         if older.sum() > 0:
             for idx in tqdm(idxs1):
                 edge_no = self.company_disclosures.iloc[idx]["edge_no"]
@@ -455,7 +455,7 @@ class DisclosuresPSE:
         newer = (
             newest_date < self.company_disclosures["Announce Date and Time"]
         )
-        idxs2 = np.argwhere(newer).flatten()
+        idxs2 = np.flatnonzero(newer)
         # append newer disclosures
         if newer.sum() > 0:
             for idx in tqdm(idxs2):


### PR DESCRIPTION
###Problem Description:
[ISSUES-85](https://github.com/enzoampil/fastquant/issues/85)

#### Solution
use instead [flatnonzero](https://docs.scipy.org/doc/numpy/reference/generated/numpy.flatnonzero.html)
```python
idxs1 = np.flatnonzero(older)
```

#### Environment
Python 3.6.9
numpy 1.18.0
pandas 1.0.3