### PR TITLE
Add crypto via get_crypto_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ get_pse_data("JFC", "2018-01-01", "2019-01-01")
 
 *Note: Python has Yahoo Finance and phisix support. R only has phisix support. Symbols from Yahoo Finance will return closing prices in USD, while symbols from PSE will return closing prices in PHP*
 
+## Get crypto data from Binance
+
+```
+from fastquant import get_crypto_data
+crypto = get_crypto_data("BTC/USDT", "2018-12-01", "2019-12-31")
+crypto.head()
+
+#             open    high     low     close    volume
+# dt                                                          
+# 2018-12-01  4041.27  4299.99  3963.01  4190.02  44840.073481
+# 2018-12-02  4190.98  4312.99  4103.04  4161.01  38912.154790
+# 2018-12-03  4160.55  4179.00  3827.00  3884.01  49094.369163
+# 2018-12-04  3884.76  4085.00  3781.00  3951.64  48489.551613
+# 2018-12-05  3950.98  3970.00  3745.00  3769.84  44004.799448
+```
+
 ## Backtest trading strategies
 
 *Note: Support for backtesting in R is pending*

--- a/python/fastquant/fastquant.py
+++ b/python/fastquant/fastquant.py
@@ -544,7 +544,7 @@ def get_crypto_data(ticker, start_date, end_date):
     )
     ohlcv_df["dt"] = pd.to_datetime(ohlcv_df["dt"], unit="ms")
     ohlcv_df = ohlcv_df[ohlcv_df.dt <= end_date]
-    return ohlcv_df
+    return ohlcv_df.set_index("dt")
 
 
 def pse_data_to_csv(symbol, start_date, end_date, pse_dir=DATA_PATH):

--- a/python/fastquant/fastquant.py
+++ b/python/fastquant/fastquant.py
@@ -528,6 +528,22 @@ def get_stock_data(symbol, start_date, end_date, source="phisix", format="c"):
     return df[df_columns]
 
 
+def unix_time_millis(date):
+    epoch = datetime.utcfromtimestamp(0)
+    dt = datetime.strptime(date, "%Y-%m-%d") 
+    #return int((dt - epoch).total_seconds() * 1000)
+    return int(dt.timestamp() * 1000)
+
+
+def get_crypto_data(ticker, start_date, end_date):
+    start_date_epoch = unix_time_millis(start_date)
+    binance = ccxt.binance({'verbose': False})
+    ohlcv_lol = binance.fetch_ohlcv(ticker, "1d", since=start_date_epoch)
+    ohlcv_df = pd.DataFrame(ohlcv_lol, columns=["dt", "open", "high", "low", "close", "volume"])
+    ohlcv_df["dt"] = pd.to_datetime(ohlcv_df['dt'], unit='ms')
+    return ohlcv_df
+
+
 def pse_data_to_csv(symbol, start_date, end_date, pse_dir=DATA_PATH):
     """
     """

--- a/python/fastquant/fastquant.py
+++ b/python/fastquant/fastquant.py
@@ -537,6 +537,11 @@ def unix_time_millis(date):
 
 
 def get_crypto_data(ticker, start_date, end_date):
+    """
+    Get crypto data in OHLCV format
+
+    List of tickers here: https://coinmarketcap.com/exchanges/binance/
+    """
     start_date_epoch = unix_time_millis(start_date)
     binance = ccxt.binance({"verbose": False})
     ohlcv_lol = binance.fetch_ohlcv(ticker, "1d", since=start_date_epoch)

--- a/python/fastquant/fastquant.py
+++ b/python/fastquant/fastquant.py
@@ -530,17 +530,19 @@ def get_stock_data(symbol, start_date, end_date, source="phisix", format="c"):
 
 def unix_time_millis(date):
     epoch = datetime.utcfromtimestamp(0)
-    dt = datetime.strptime(date, "%Y-%m-%d") 
-    #return int((dt - epoch).total_seconds() * 1000)
+    dt = datetime.strptime(date, "%Y-%m-%d")
+    # return int((dt - epoch).total_seconds() * 1000)
     return int(dt.timestamp() * 1000)
 
 
 def get_crypto_data(ticker, start_date, end_date):
     start_date_epoch = unix_time_millis(start_date)
-    binance = ccxt.binance({'verbose': False})
+    binance = ccxt.binance({"verbose": False})
     ohlcv_lol = binance.fetch_ohlcv(ticker, "1d", since=start_date_epoch)
-    ohlcv_df = pd.DataFrame(ohlcv_lol, columns=["dt", "open", "high", "low", "close", "volume"])
-    ohlcv_df["dt"] = pd.to_datetime(ohlcv_df['dt'], unit='ms')
+    ohlcv_df = pd.DataFrame(
+        ohlcv_lol, columns=["dt", "open", "high", "low", "close", "volume"]
+    )
+    ohlcv_df["dt"] = pd.to_datetime(ohlcv_df["dt"], unit="ms")
     return ohlcv_df
 
 

--- a/python/fastquant/fastquant.py
+++ b/python/fastquant/fastquant.py
@@ -24,6 +24,7 @@ from nltk.sentiment.vader import SentimentIntensityAnalyzer
 import nltk
 from urllib.request import urlopen
 from bs4 import BeautifulSoup
+import ccxt
 
 DATA_PATH = resource_filename(__name__, "data")
 

--- a/python/fastquant/fastquant.py
+++ b/python/fastquant/fastquant.py
@@ -543,6 +543,7 @@ def get_crypto_data(ticker, start_date, end_date):
         ohlcv_lol, columns=["dt", "open", "high", "low", "close", "volume"]
     )
     ohlcv_df["dt"] = pd.to_datetime(ohlcv_df["dt"], unit="ms")
+    ohlcv_df = ohlcv_df[ohlcv_df.dt <= end_date]
     return ohlcv_df
 
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,6 +2,7 @@ backtrader==1.9.75.123
 beautifulsoup4==4.8.2
 black==19.10b0
 bs4==0.0.1
+ccxt==1.30.59
 certifi==2019.11.28
 chardet==3.0.4
 idna==2.8

--- a/python/tests/test_fastquant.py
+++ b/python/tests/test_fastquant.py
@@ -3,10 +3,12 @@ from fastquant import (
     get_pse_data,
     get_yahoo_data,
     get_stock_data,
+    get_crypto_data,
     pse_data_to_csv,
 )
 
 PHISIX_SYMBOL = "JFC"
+CRYPTO_SYMBOL = "BTC/USDT"
 YAHOO_SYMBOL = "GOOGL"
 DATE_START = "2018-01-01"
 DATE_END = "2019-01-01"
@@ -32,3 +34,8 @@ def test_get_stock_data():
         YAHOO_SYMBOL, DATE_START, DATE_END, source="yahoo"
     )
     assert isinstance(stock_df, pd.DataFrame)
+
+
+def test_get_crypto_data():
+    crypto_df = get_crypto_data(CRYPTO_SYMBOL, DATE_START, DATE_END)
+    assert isinstance(crypto_df, pd.DataFrame)


### PR DESCRIPTION
**This PR adds the `get_crypto_data` function which returns crypto data from binance in OHLCV format.**

This should resolve issue #92 and you can test it out in this colab [link](https://colab.research.google.com/drive/1uJToo_8BcyQ38N39XqQKw4lwvoKFnAO1?usp=sharing).

Sample usage:

```
# Install branch
!pip install -e git+git://github.com/enzoampil/fastquant.git@add_crypto#egg=fastquant

from fastquant import get_crypto_data

crypto = get_crypto_data("BTC/USDT", "2018-12-01", "2019-12-31")
crypto

            open    high     low     close    volume
dt                                                          
2018-12-01  4041.27  4299.99  3963.01  4190.02  44840.073481
2018-12-02  4190.98  4312.99  4103.04  4161.01  38912.154790
2018-12-03  4160.55  4179.00  3827.00  3884.01  49094.369163
2018-12-04  3884.76  4085.00  3781.00  3951.64  48489.551613
2018-12-05  3950.98  3970.00  3745.00  3769.84  44004.799448
...             ...      ...      ...      ...           ...
2019-12-27  7202.00  7275.86  7076.42  7254.74  33642.701861
2019-12-28  7254.77  7365.01  7238.67  7316.14  26848.982199
2019-12-29  7315.36  7528.45  7288.00  7388.24  31387.106085
2019-12-30  7388.43  7408.24  7220.00  7246.00  29605.911782
2019-12-31  7246.00  7320.00  7145.01  7195.23  25954.453533

```

