### PR TITLE
refactor sentiment strat

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E203, E266, E501, W503, F403, F401
+ignore = E203, E266, E501, W503, F403, F401, C901
 max-line-length = 79
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/python/fastquant/fastquant.py
+++ b/python/fastquant/fastquant.py
@@ -574,7 +574,7 @@ def datestring_to_datetime(date, sep="-"):
     return datetime(*map(int, ymd))
 
 
-def get_bt_news(keyword, page_nums=None):
+def get_bt_news_sentiment(keyword, page_nums=None):
     """
     This function scrapes Business Times (https://www.businesstimes.com.sg) articles by giving
     a specific keyword e.g "facebook, jollibee" and number of pages that you needed.
@@ -590,6 +590,8 @@ def get_bt_news(keyword, page_nums=None):
     ----------
     date_sentiments: dict
         The dictionary output of the scraped data in form of {date: sentiment score}
+
+    TO DO: change page_nums to a start_date (and end_date maybe)
     """
 
     nltk.download("vader_lexicon", quiet=True)  # download vader lexicon

--- a/python/fastquant/indicators.py
+++ b/python/fastquant/indicators.py
@@ -20,16 +20,9 @@ class Sentiment(bt.Indicator):
     """
     Sentiment Custom Indicator
     Implementation of sentiment custom indicator using nltk/textblob pre-built sentiment models
-
-    Parameters
-    ----------
-    agg_sentiment : dict
-        The scraped dictionary with key, value pair of date, sentiment score. This is handled automatically by get_bt_news in senti_scraper.
-
     """
 
     lines = ("sentiment",)
-    params = (("agg_sentiment", None),)
 
     plotinfo = dict(
         plotymargin=0.15, plothlines=[0], plotyticks=[1.0, 0, -1.0]
@@ -52,7 +45,4 @@ class Sentiment(bt.Indicator):
         return
 
     def next(self):
-        date = self.datas[0].datetime.date(0)
-        agg_sentiment = self.params.agg_sentiment
-        if date in agg_sentiment:
-            self.lines.sentiment[0] = agg_sentiment[date]
+        self.lines.sentiment[0] = self.datas[0].sentiment_score[0]

--- a/python/fastquant/strategies.py
+++ b/python/fastquant/strategies.py
@@ -19,7 +19,7 @@ import pandas as pd
 import numpy as np
 from collections.abc import Iterable
 import time
-from .fastquant import get_bt_news
+from .fastquant import get_bt_news_sentiment
 from .indicators import Sentiment
 
 # Global arguments
@@ -99,6 +99,7 @@ class BaseStrategy(bt.Strategy):
 
         self.dataclose = self.datas[0].close
         self.dataopen = self.datas[0].open
+
         self.order = None
         self.buyprice = None
         self.buycomm = None
@@ -194,6 +195,7 @@ class BaseStrategy(bt.Strategy):
 
                 if self.transaction_logging:
                     self.log("BUY CREATE, %.2f" % self.dataclose[0])
+                #    self.log("SENTIMENT, %.2f" % self.datasentiment[0])
                 # Take a 10% long position every time it's a buy signal (or whatever is afforded by the current cash position)
                 # "size" refers to the number of stocks to purchase
                 # Afforded size is based on closing price for the current trading day
@@ -528,52 +530,29 @@ class SentimentStrategy(BaseStrategy):
 
     Parameters
     ----------
-    keyword : str
-        The keyword you wanted to search for in Business Times page.
-    page_nums : int
-        The number of iteration of pages you want to scrape.
     senti : float
         The sentiment score threshold to indicate when to buy/sell
 
-    TODO: Textblob implementation in the custom_indicators for Sentiment indicator
+    TODO: Textblob implementation for Sentiment indicator
 
     """
 
-    params = (
-        ("page_nums", 1),
-        ("senti", 0.2),
-    )
+    params = (("senti", 0.2),)
 
-    def __init__(self, keyword):
+    def __init__(self):
         # Initialize global variables
         super().__init__()
         # Strategy level variables
-        self.keyword = keyword
-        errmsg = "provide `keyword` used for news article scraping"
-        assert keyword is not None, errmsg
-
-        self.page_nums = self.params.page_nums
         self.senti = self.params.senti
-
         print("===Strategy level arguments===")
-        print("keyword for news scraping:", self.keyword)
-        print(
-            "page numbers to scrape in https://www.businesstimes.com.sg/search/{}? : ".format(
-                self.keyword
-            ),
-            self.page_nums,
-        )
         print("sentiment threshold :", self.senti)
-        self.agg_sentiment = get_bt_news(
-            keyword=self.keyword, page_nums=self.page_nums
-        )
-        self.sentiment = Sentiment(agg_sentiment=self.agg_sentiment)
+        self.datasentiment = Sentiment(self.data)
 
     def buy_signal(self):
-        return self.sentiment[0] >= self.senti
+        return self.datasentiment[0] >= self.senti
 
     def sell_signal(self):
-        return self.sentiment[0] <= self.senti
+        return self.datasentiment[0] <= self.senti
 
 
 STRATEGY_MAPPING = {
@@ -592,6 +571,15 @@ strat_docs = "\nExisting strategies:\n\n" + "\n".join(
 )
 
 
+class SentimentDF(bt.feeds.PandasData):
+    # Add a 'sentiment_score' line to the inherited ones from the base class
+    lines = ("sentiment_score",)
+
+    # automatically handle parameter with -1
+    # add the parameter to the parameters inherited from the base class
+    params = (("sentiment_score", -1),)
+
+
 @docstring_parameter(strat_docs)
 def backtest(
     strategy,
@@ -602,6 +590,7 @@ def backtest(
     plot=True,
     verbose=True,
     sort_by="rnorm",
+    sentiments=None,
     strats=None,  # Only used when strategy = "multi"
     **kwargs
 ):
@@ -655,14 +644,32 @@ def backtest(
             print("Reading path as pandas dataframe ...")
         data = pd.read_csv(data, header=0, parse_dates=["dt"])
 
-    # If data has `dt` as the index, set `dt` as the first column
-    # This means `backtest` supports the dataframe whether `dt` is the index or a column
-    if data.index.name == "dt":
+    # extend the dataframe with sentiment score
+    if strategy == "sentiment":
+        # initialize series for sentiments
+        senti_series = pd.Series(
+            sentiments, name="sentiment_score", dtype=float
+        )
+
+        # join and reset the index for dt to become the first column
+        data = data.merge(
+            senti_series, left_index=True, right_index=True, how="left"
+        )
         data = data.reset_index()
 
-    pd_data = bt.feeds.PandasData(
-        dataname=data, **DATA_FORMAT_MAPPING[data_format]
-    )
+        # create PandasData using SentimentDF
+        pd_data = SentimentDF(
+            dataname=data, **DATA_FORMAT_MAPPING[data_format]
+        )
+
+    else:
+        # If data has `dt` as the index, set `dt` as the first column
+        # This means `backtest` supports the dataframe whether `dt` is the index or a column
+        if data.index.name == "dt":
+            data = data.reset_index()
+        pd_data = bt.feeds.PandasData(
+            dataname=data, **DATA_FORMAT_MAPPING[data_format]
+        )
 
     cerebro.adddata(pd_data)
     cerebro.broker.setcash(init_cash)

--- a/python/fastquant/strategies.py
+++ b/python/fastquant/strategies.py
@@ -195,7 +195,6 @@ class BaseStrategy(bt.Strategy):
 
                 if self.transaction_logging:
                     self.log("BUY CREATE, %.2f" % self.dataclose[0])
-                #    self.log("SENTIMENT, %.2f" % self.datasentiment[0])
                 # Take a 10% long position every time it's a buy signal (or whatever is afforded by the current cash position)
                 # "size" refers to the number of stocks to purchase
                 # Afforded size is based on closing price for the current trading day

--- a/python/tests/test_strategies.py
+++ b/python/tests/test_strategies.py
@@ -1,6 +1,12 @@
 import pandas as pd
 from pathlib import Path
-from fastquant import backtest, STRATEGY_MAPPING, DATA_PATH, get_yahoo_data
+from fastquant import (
+    backtest,
+    STRATEGY_MAPPING,
+    DATA_PATH,
+    get_yahoo_data,
+    get_bt_news_sentiment,
+)
 
 SAMPLE_CSV = Path(DATA_PATH, "JFC_20180101_20190110_DCV.csv")
 SAMPLE_STRAT_DICT = {
@@ -16,9 +22,10 @@ def test_backtest():
     sample = pd.read_csv(SAMPLE_CSV, parse_dates=["dt"])
     for strategy in STRATEGY_MAPPING.keys():
         if strategy == "sentiment":
-            data = get_yahoo_data("TSLA", "2020-01-01", "2020-06-10")
+            data = get_yahoo_data("TSLA", "2020-01-01", "2020-07-04")
+            sentiments = get_bt_news_sentiment(keyword="tesla", page_nums=1)
             cerebro = backtest(
-                strategy, data, keyword="tesla", page_nums=2, senti=0.4
+                strategy, data, sentiments=sentiments, senti=0.4
             )
             errmsg = "Backtest encountered error for strategy '{}'!".format(
                 strategy


### PR DESCRIPTION
This PR Generalizes the `SentimentStrategy` to be compatible with Disclosures and Twitter
Notable Changes in the repo:
`strategies.py`
added a Custom `SentimentDF` class which extends `PandasData` datafeed to have `sentiment_score` column which can then be accessed inside via `self.data.sentiment_score`
changed `get_bt_news` to `get_bt_news_sentiment` to make it more transparent to the user.

more info in collab [link](https://colab.research.google.com/drive/1ahl0o7BBR1ULhM8e6blcSt7_BniFnTXb?usp=sharing)
