### PR TITLE
Include backtrader indicators to fastquant via import

### DIFF
--- a/python/fastquant/indicators/__init__.py
+++ b/python/fastquant/indicators/__init__.py
@@ -1,3 +1,6 @@
 # Modules available for fastquant.indicators.*
 
 from fastquant.indicators.sentiment import Sentiment
+
+# Import backtrader indicators
+from backtrader.indicators import *


### PR DESCRIPTION
Needed insights whether to just use `import *` to include everything (at a slight cost of loading all indicators) or import them individually (and probably to avoid class name conflicts)