### PR TITLE
Dynamic data format without specifying data_format in `backtest`

### DIFF
--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -68,6 +68,22 @@ def docstring_parameter(*sub):
     return dec
 
 
+@docstring_parameter(", ".join(list(DATA_FORMAT_MAPPING.keys())))
+def infer_data_format(data):
+    """
+    Infers the data format of the dataframe based on the indices of its matched column names
+
+    The detectable column names are {0}
+    """
+    cols = data.columns.values.tolist()
+    detectable_cols = list(DATA_FORMAT_MAPPING.keys())
+    # Detected columns are those that are in both the dataframe and the list of detectable columns
+    detected_cols = set(cols).intersection(detectable_cols)
+    # Assertion error if no columns were detected
+    assert detected_cols, "No columns were detected! Please have at least one of: {}".format(detectable_cols)
+    data_format = {key for key in DATA_FORMAT_MAPPING.items()}
+
+
 @docstring_parameter(strat_docs)
 def backtest(
     strategy,

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -70,7 +70,7 @@ def docstring_parameter(*sub):
     return dec
 
 
-@docstring_parameter(", ".join(["dt"] + list(DATA_FORMAT_MAPPING.keys())))
+@docstring_parameter(", ".join(["dt"] + list(DATA_FORMAT_BASE.keys())))
 def infer_data_format(data):
     """
     Infers the data format of the dataframe based on the indices of its matched column names
@@ -80,7 +80,7 @@ def infer_data_format(data):
     # Rename "dt" column to "datetime" to match the formal alias
     data = data.rename(columns={"dt": "datetime"})
     cols = data.columns.values.tolist()
-    detectable_cols = list(DATA_FORMAT_MAPPING.keys())
+    detectable_cols = list(DATA_FORMAT_BASE.keys())
     # Detected columns are those that are in both the dataframe and the list of detectable columns
     detected_cols = set(cols).intersection(detectable_cols)
     # Assertion error if no columns were detected

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -99,12 +99,12 @@ def backtest(
     data,  # Treated as csv path is str, and dataframe of pd.DataFrame
     commission=COMMISSION_PER_TRANSACTION,
     init_cash=INIT_CASH,
-    data_format=None, # If none, format is automatically inferred
     plot=True,
     verbose=True,
     sort_by="rnorm",
     sentiments=None,
     strats=None,  # Only used when strategy = "multi"
+    data_format=None,  # If none, format is automatically inferred
     **kwargs
 ):
     """

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -109,8 +109,28 @@ def backtest(
     data_format=None,  # If none, format is automatically inferred
     **kwargs
 ):
-    """
-    Backtest financial data with a specified trading strategy
+    """Backtest financial data with a specified trading strategy
+
+    Parameters
+    ----------------
+    strategy : str 
+        see list of accepted strategy keys below
+    data : pandas.DataFrame
+        dataframe with at least close price indexed with time
+    commission : float
+        commission per transaction [0, 1]
+    init_cash : float
+        initial cash (currency implied from `data`)
+    plot : bool
+        show plot backtrader (disabled if `strategy`=="multi")
+    sort_by : str
+        sort result by given metric (default='rnorm')
+    sentiments : pandas.DataFrame
+        df of sentiment [0, 1] indexed by time (applicable if `strategy`=='senti')
+    strats : dict
+        dictionary of strategy parameters (applicable if `strategy`=='multi')
+    data_format : str
+        input data format e.g. ohlcv (default=None so format is automatically inferred)
 
     {0}
     """

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -87,7 +87,8 @@ def infer_data_format(data):
     assert detected_cols, "No columns were detected! Please have at least one of: {}".format(detectable_cols)
     # Set data format mapping
     data_format = {k: cols.index(k) if k in detected_cols else None for k, _ in DATA_FORMAT_BASE.items()}
-    data_format_alias = {DATA_FORMAT_COLS[k]: v for k, v in data_format.items()}
+    cols_to_alias = {v: k for k, v in DATA_FORMAT_COLS.items()}
+    data_format_alias = {cols_to_alias[k]: v for k, v in data_format.items()}
     data_format_str = "".join(pd.Series(data_format_alias).dropna().sort_values().index.values.tolist())
     print("Data format detected:", data_format_str)
     return data_format

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -88,7 +88,8 @@ def infer_data_format(data):
     # Set data format mapping
     data_format = {k: cols.index(k) if k in detected_cols else None for k, _ in DATA_FORMAT_BASE.items()}
     cols_to_alias = {v: k for k, v in DATA_FORMAT_COLS.items()}
-    data_format_alias = {cols_to_alias[k]: v for k, v in data_format.items()}
+    # Ignore "datetime" since it's assumed to be there when writing the alias
+    data_format_alias = {cols_to_alias[k]: v for k, v in data_format.items() if k != "datetime"}
     data_format_str = "".join(pd.Series(data_format_alias).dropna().sort_values().index.values.tolist())
     print("Data format detected:", data_format_str)
     return data_format

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -275,7 +275,7 @@ def backtest(
     print("Optimal metrics:", optim_metrics)
 
     if plot and strategy != "multi":
-        has_volume = DATA_FORMAT_MAPPING[data_format]["volume"] is not None
+        has_volume = data_format_dict["volume"] is not None
         # Plot only with the optimal parameters when multiple strategy runs are required
         if params_df.shape[0] == 1:
             # This handles the Colab Plotting

--- a/python/fastquant/config.py
+++ b/python/fastquant/config.py
@@ -10,6 +10,17 @@ DATA_FILE = resource_filename(__name__, "data/JFC_20180101_20190110_DCV.csv")
 
 BUY_PROP = 1
 SELL_PROP = 1
+
+DATA_FORMAT_BASE = {
+        "datetime": None,
+        "open": None,
+        "high": None,
+        "low": None,
+        "close": None,
+        "volume": None,
+        "openinterest": None,
+    }
+
 DATA_FORMAT_MAPPING = {
     "cv": {
         "datetime": 0,


### PR DESCRIPTION
This PR which should resolve issue #83 allows for the data format of a dataframe used as an input in `backtest` to be automatically inferred based on the column names. Detectable column names can be found as keys in `config.DATA_FORMAT_BASE` (aside from `dt`).

@jpdeleon mind reviewing since we were the ones working this before? :smile: