### PR TITLE
[FEATURE] Custom indicator support for forecasting use cases

### DIFF
--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -85,6 +85,7 @@ def backtest(
     sort_by="rnorm",
     sentiments=None,
     strats=None,  # Only used when strategy = "multi"
+    data_format=None,  # No longer needed but will leave for now to warn removal in a coming release
     **kwargs
 ):
     """Backtest financial data with a specified trading strategy
@@ -110,6 +111,10 @@ def backtest(
 
     {0}
     """
+
+    if data_format:
+        print("Warning: data_format argument is no longer needed since formatting is now purely automated based on column names!")
+        print("We will be removing this argument in a coming release!")
 
     # Setting inital support for 1 cpu
     # Return the full strategy object to get all run information

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -181,6 +181,17 @@ def backtest(
             print("Reading path as pandas dataframe ...")
         data = pd.read_csv(data, header=0, parse_dates=["dt"])
 
+    class CustomData(bt.feeds.PandasData):
+        """
+        Data feed that includes all the columns in the input dataframe
+        """
+        # Add a custom lines to the inherited ones from the base class
+        lines = tuple(data.columns)
+
+        # automatically handle parameter with -1
+        # add the parameter to the parameters inherited from the base class
+        params = tuple([(col, -1) for col in data.columns])
+
     # extend the dataframe with sentiment score
     if strategy == "sentiment":
         # initialize series for sentiments
@@ -206,7 +217,7 @@ def backtest(
         if data.index.name == "dt":
             data = data.reset_index()
         data_format_dict = DATA_FORMAT_MAPPING[data_format] if data_format else infer_data_format(data)
-        pd_data = bt.feeds.PandasData(
+        pd_data = CustomData(
             dataname=data, **data_format_dict
         )
 

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -319,7 +319,6 @@ def backtest(
                 strategy,
                 data,  # Treated as csv path is str, and dataframe of pd.DataFrame
                 commission=commission,
-                data_format=data_format,
                 plot=plot,
                 verbose=verbose,
                 sort_by=sort_by,

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -79,29 +79,6 @@ def tuple_to_dict(tup):
     return di
 
 
-@docstring_parameter(", ".join(["dt"] + list(DATA_FORMAT_BASE.keys())))
-def infer_data_format(data):
-    """
-    Infers the data format of the dataframe based on the indices of its matched column names
-
-    The detectable column names are {0}
-    """
-    cols = data.columns.values.tolist()
-    detectable_cols = list(DATA_FORMAT_BASE.keys())
-    # Detected columns are those that are in both the dataframe and the list of detectable columns
-    detected_cols = set(cols).intersection(detectable_cols)
-    # Assertion error if no columns were detected
-    assert detected_cols, "No columns were detected! Please have at least one of: {}".format(detectable_cols)
-    # Set data format mapping
-    data_format = {k: cols.index(k) if k in detected_cols else None for k, _ in DATA_FORMAT_BASE.items()}
-    cols_to_alias = {v: k for k, v in DATA_FORMAT_COLS.items()}
-    # Ignore "datetime" since it's assumed to be there when writing the alias
-    data_format_alias = {cols_to_alias[k]: v for k, v in data_format.items() if k != "datetime"}
-    data_format_str = "".join(pd.Series(data_format_alias).dropna().sort_values().index.values.tolist())
-    print("Data format detected:", data_format_str)
-    return data_format
-
-
 @docstring_parameter(strat_docs)
 def backtest(
     strategy,
@@ -113,7 +90,6 @@ def backtest(
     sort_by="rnorm",
     sentiments=None,
     strats=None,  # Only used when strategy = "multi"
-    data_format=None,  # If none, format is automatically inferred
     **kwargs
 ):
     """Backtest financial data with a specified trading strategy
@@ -136,8 +112,6 @@ def backtest(
         df of sentiment [0, 1] indexed by time (applicable if `strategy`=='senti')
     strats : dict
         dictionary of strategy parameters (applicable if `strategy`=='multi')
-    data_format : str
-        input data format e.g. ohlcv (default=None so format is automatically inferred)
 
     {0}
     """

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -7,9 +7,7 @@ from __future__ import (
     print_function,
     unicode_literals,
 )
-from pkg_resources import resource_filename
-import datetime
-import sys
+import warnings
 
 # Import modules
 import backtrader as bt
@@ -113,8 +111,10 @@ def backtest(
     """
 
     if data_format:
-        print("Warning: data_format argument is no longer needed since formatting is now purely automated based on column names!")
-        print("We will be removing this argument in a coming release!")
+        errmsg = "Warning: data_format argument is no longer needed since formatting is now purely automated based on column names!"
+        errmsg += "\nWe will be removing this argument in a coming release!"
+        warnings.warn(errmsg, DeprecationWarning)
+        print(errmsg)
 
     # Setting inital support for 1 cpu
     # Return the full strategy object to get all run information

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -197,6 +197,20 @@ def backtest(
     data = data.rename(columns={"dt": "datetime"})
     data["datetime"] = pd.to_datetime(data.datetime)
     print(data.columns)
+
+    if strategy == "sentiment":
+        # initialize series for sentiments
+        senti_series = pd.Series(
+            sentiments, name="sentiment_score", dtype=float
+        )
+
+        # join and reset the index for dt to become the first column
+        data = data.merge(
+            senti_series, left_index=True, right_index=True, how="left"
+        )
+        data = data.reset_index()
+        #data_format_dict = DATA_FORMAT_MAPPING[data_format] if data_format else infer_data_format(data)
+
     numeric_cols = [col for col in data.columns if is_numeric_dtype(data[col])]
     params_tuple = tuple([(col, i) for i, col in enumerate(data.columns) if col in numeric_cols + ["datetime"]])
     default_cols = [c for c, _ in DEFAULT_PANDAS]
@@ -216,22 +230,9 @@ def backtest(
 
     # extend the dataframe with sentiment score
     if strategy == "sentiment":
-        # initialize series for sentiments
-        senti_series = pd.Series(
-            sentiments, name="sentiment_score", dtype=float
-        )
-
-        # join and reset the index for dt to become the first column
-        data = data.merge(
-            senti_series, left_index=True, right_index=True, how="left"
-        )
-        data = data.reset_index()
-        data = data.rename(columns={"dt": "datetime"})
-        data["datetime"] = pd.to_datetime(data["datetime"])
-        data_format_dict = DATA_FORMAT_MAPPING[data_format] if data_format else infer_data_format(data)
-
+        data_format_dict = tuple_to_dict(params_tuple)
         # create PandasData using SentimentDF
-        pd_data = SentimentDF(
+        pd_data = CustomData(
             dataname=data, **data_format_dict
         )
 

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -35,6 +35,7 @@ from fastquant.strategies import (
     CustomStrategy,
 )
 
+
 # Import backtest variables
 from fastquant.config import (
     INIT_CASH,
@@ -96,7 +97,7 @@ def backtest(
 
     Parameters
     ----------------
-    strategy : str 
+    strategy : str
         see list of accepted strategy keys below
     data : pandas.DataFrame
         dataframe with at least close price indexed with time
@@ -184,18 +185,27 @@ def backtest(
     data["datetime"] = pd.to_datetime(data.datetime)
 
     numeric_cols = [col for col in data.columns if is_numeric_dtype(data[col])]
-    params_tuple = tuple([(col, i) for i, col in enumerate(data.columns) if col in numeric_cols + ["datetime"]])
+    params_tuple = tuple(
+        [
+            (col, i)
+            for i, col in enumerate(data.columns)
+            if col in numeric_cols + ["datetime"]
+        ]
+    )
     default_cols = [c for c, _ in DEFAULT_PANDAS]
-    non_default_numeric_cols = tuple([col for col, _ in params_tuple if col not in default_cols])
+    non_default_numeric_cols = tuple(
+        [col for col, _ in params_tuple if col not in default_cols]
+    )
 
     class CustomData(bt.feeds.PandasData):
         """
         Data feed that includes all the columns in the input dataframe
         """
+
         # Need to make sure that the new lines don't overlap w/ the default lines already in PandasData
         lines = non_default_numeric_cols
         print(lines)
-        
+
         # automatically handle parameter with -1
         # add the parameter to the parameters inherited from the base class
         params = params_tuple
@@ -204,15 +214,11 @@ def backtest(
     if strategy == "sentiment":
         data_format_dict = tuple_to_dict(params_tuple)
         # create PandasData using SentimentDF
-        pd_data = CustomData(
-            dataname=data, **data_format_dict
-        )
+        pd_data = CustomData(dataname=data, **data_format_dict)
 
     else:
         data_format_dict = tuple_to_dict(params_tuple)
-        pd_data = CustomData(
-            dataname=data, **data_format_dict
-        )
+        pd_data = CustomData(dataname=data, **data_format_dict)
 
     cerebro.adddata(pd_data)
     cerebro.broker.setcash(init_cash)

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -32,6 +32,7 @@ from fastquant.strategies import (
     BBandsStrategy,
     BuyAndHoldStrategy,
     SentimentStrategy,
+    CustomStrategy,
 )
 
 # Import backtest variables
@@ -56,6 +57,7 @@ STRATEGY_MAPPING = {
     "bbands": BBandsStrategy,
     "buynhold": BuyAndHoldStrategy,
     "sentiment": SentimentStrategy,
+    "custom": CustomStrategy,
 }
 
 strat_docs = "\nExisting strategies:\n\n" + "\n".join(

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -22,7 +22,6 @@ import time
 from pandas.api.types import is_numeric_dtype
 
 # Import from package
-from fastquant.strategies.sentiment import SentimentDF
 from fastquant.strategies import (
     RSIStrategy,
     SMACStrategy,
@@ -40,12 +39,7 @@ from fastquant.strategies import (
 from fastquant.config import (
     INIT_CASH,
     COMMISSION_PER_TRANSACTION,
-    DATA_FORMAT_MAPPING,
-    # strat_docs,
-    # STRATEGY_MAPPING,
     GLOBAL_PARAMS,
-    DATA_FORMAT_BASE,
-    DATA_FORMAT_COLS,
     DEFAULT_PANDAS,
 )
 
@@ -212,7 +206,7 @@ def backtest(
     # extend the dataframe with sentiment score
     if strategy == "sentiment":
         data_format_dict = tuple_to_dict(params_tuple)
-        # create PandasData using SentimentDF
+        # create CustomData which inherits from PandasData
         pd_data = CustomData(dataname=data, **data_format_dict)
 
     else:

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -204,7 +204,6 @@ def backtest(
 
         # Need to make sure that the new lines don't overlap w/ the default lines already in PandasData
         lines = non_default_numeric_cols
-        print(lines)
 
         # automatically handle parameter with -1
         # add the parameter to the parameters inherited from the base class

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -188,15 +188,6 @@ def backtest(
             print("Reading path as pandas dataframe ...")
         # Rename dt to datetime
         data = pd.read_csv(data, header=0, parse_dates=["dt"])
-    
-    # If data has `dt` as the index, set `dt` as the first column
-    # This means `backtest` supports the dataframe whether `dt` is the index or a column
-    if data.index.name == "dt":
-        data = data.reset_index()
-    # Rename "dt" column to "datetime" to match the formal alias
-    data = data.rename(columns={"dt": "datetime"})
-    data["datetime"] = pd.to_datetime(data.datetime)
-    print(data.columns)
 
     if strategy == "sentiment":
         # initialize series for sentiments
@@ -209,7 +200,14 @@ def backtest(
             senti_series, left_index=True, right_index=True, how="left"
         )
         data = data.reset_index()
-        #data_format_dict = DATA_FORMAT_MAPPING[data_format] if data_format else infer_data_format(data)
+
+    # If data has `dt` as the index, set `dt` as the first column
+    # This means `backtest` supports the dataframe whether `dt` is the index or a column
+    if data.index.name == "dt":
+        data = data.reset_index()
+    # Rename "dt" column to "datetime" to match the formal alias
+    data = data.rename(columns={"dt": "datetime"})
+    data["datetime"] = pd.to_datetime(data.datetime)
 
     numeric_cols = [col for col in data.columns if is_numeric_dtype(data[col])]
     params_tuple = tuple([(col, i) for i, col in enumerate(data.columns) if col in numeric_cols + ["datetime"]])
@@ -237,13 +235,7 @@ def backtest(
         )
 
     else:
-        #data_format_dict = DATA_FORMAT_MAPPING[data_format] if data_format else infer_data_format(data)
         data_format_dict = tuple_to_dict(params_tuple)
-        #for p, i in params_tuple:
-        #    if p not in data_format_dict.keys():
-        #        data_format_dict[p] = i
-
-        print(data_format_dict)
         pd_data = CustomData(
             dataname=data, **data_format_dict
         )

--- a/python/fastquant/config.py
+++ b/python/fastquant/config.py
@@ -21,16 +21,6 @@ DEFAULT_PANDAS = (
     ("openinterest", -1),
 )
 
-DATA_FORMAT_BASE = {
-    "datetime": None,
-    "open": None,
-    "high": None,
-    "low": None,
-    "close": None,
-    "volume": None,
-    "openinterest": None,
-}
-
 DATA_FORMAT_MAPPING = {
     "cv": {
         "datetime": 0,

--- a/python/fastquant/config.py
+++ b/python/fastquant/config.py
@@ -11,6 +11,16 @@ DATA_FILE = resource_filename(__name__, "data/JFC_20180101_20190110_DCV.csv")
 BUY_PROP = 1
 SELL_PROP = 1
 
+DEFAULT_PANDAS = (
+        ('datetime', None),
+        ('open', -1),
+        ('high', -1),
+        ('low', -1),
+        ('close', -1),
+        ('volume', -1),
+        ('openinterest', -1),
+    )
+
 DATA_FORMAT_BASE = {
         "datetime": None,
         "open": None,

--- a/python/fastquant/config.py
+++ b/python/fastquant/config.py
@@ -12,24 +12,24 @@ BUY_PROP = 1
 SELL_PROP = 1
 
 DEFAULT_PANDAS = (
-        ('datetime', None),
-        ('open', -1),
-        ('high', -1),
-        ('low', -1),
-        ('close', -1),
-        ('volume', -1),
-        ('openinterest', -1),
-    )
+    ("datetime", None),
+    ("open", -1),
+    ("high", -1),
+    ("low", -1),
+    ("close", -1),
+    ("volume", -1),
+    ("openinterest", -1),
+)
 
 DATA_FORMAT_BASE = {
-        "datetime": None,
-        "open": None,
-        "high": None,
-        "low": None,
-        "close": None,
-        "volume": None,
-        "openinterest": None,
-    }
+    "datetime": None,
+    "open": None,
+    "high": None,
+    "low": None,
+    "close": None,
+    "volume": None,
+    "openinterest": None,
+}
 
 DATA_FORMAT_MAPPING = {
     "cv": {

--- a/python/fastquant/indicators/custom.py
+++ b/python/fastquant/indicators/custom.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Import standard library
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
+from pkg_resources import resource_filename
+import datetime
+import sys
+
+# Import modules
+import backtrader as bt
+
+
+class CustomIndicator(bt.Indicator):
+
+    """
+    Custom Indicator
+    Implementation of sentiment custom indicator using nltk/textblob pre-built sentiment models
+    """
+
+    lines = ("sentiment",)
+
+    plotinfo = dict(
+        plotymargin=0.15, plothlines=[0], plotyticks=[1.0, 0, -1.0]
+    )
+
+    plotlines = dict(
+        sentiment=dict(
+            alpha=0.85,
+            width=1.0,
+            _method="bar",
+            _plotvalue=True,
+            _plotvaluetag=False,
+            _name=" ",
+            _skipnan=True,
+            _samecolor=False,
+        )
+    )
+
+    def _plotlabel(self):
+        return
+
+    def next(self):
+        self.lines.sentiment[0] = self.datas[0].sentiment_score[0]

--- a/python/fastquant/indicators/custom.py
+++ b/python/fastquant/indicators/custom.py
@@ -25,10 +25,8 @@ class CustomIndicator(bt.Indicator):
 
     params = (
         ("custom_column", "custom"),
-    )
-
-    plotinfo = dict(
-        plotymargin=0.15, plothlines=[0], plotyticks=[1.0, 0, -1.0]
+        ("upper_limit", 80),
+        ("lower_limit", 20),
     )
 
     plotlines = dict(
@@ -47,6 +45,13 @@ class CustomIndicator(bt.Indicator):
     def __init__(self):
         super().__init__()
         self.custom_column = self.params.custom_column
+        self.upper_limit = self.params.upper_limit
+        self.lower_limit = self.params.lower_limit
+
+        # Plotting lines are based on the upper and lower limits
+        CustomIndicator.plotinfo = dict(
+            plotymargin=0.15, plothlines=[0], plotyticks=[self.upper_limit, self.lower_limit]
+        )
 
     def _plotlabel(self):
         return

--- a/python/fastquant/indicators/custom.py
+++ b/python/fastquant/indicators/custom.py
@@ -23,6 +23,10 @@ class CustomIndicator(bt.Indicator):
 
     lines = ("custom",)
 
+    params = (
+        ("custom_column", "custom"),
+    )
+
     plotinfo = dict(
         plotymargin=0.15, plothlines=[0], plotyticks=[1.0, 0, -1.0]
     )
@@ -40,8 +44,11 @@ class CustomIndicator(bt.Indicator):
         )
     )
 
+    def __init__(self):
+        self.custom_column = self.params.custom_column
+
     def _plotlabel(self):
         return
 
     def next(self):
-        self.lines.custom[0] = self.datas[0].custom[0]
+        self.lines.custom[0] = getattr(self.datas[0], self.custom_column)[0]

--- a/python/fastquant/indicators/custom.py
+++ b/python/fastquant/indicators/custom.py
@@ -45,6 +45,7 @@ class CustomIndicator(bt.Indicator):
     )
 
     def __init__(self):
+        super().__init__()
         self.custom_column = self.params.custom_column
 
     def _plotlabel(self):

--- a/python/fastquant/indicators/custom.py
+++ b/python/fastquant/indicators/custom.py
@@ -26,20 +26,7 @@ class CustomIndicator(bt.Indicator):
     params = (
         ("custom_column", "custom"),
     )
-
-    plotlines = dict(
-        sentiment=dict(
-            alpha=0.85,
-            width=1.0,
-            _method="bar",
-            _plotvalue=True,
-            _plotvaluetag=False,
-            _name=" ",
-            _skipnan=True,
-            _samecolor=False,
-        )
-    )
-
+        
     plotinfo = dict(
         plotymargin=0.15,
         plothlines=[0],

--- a/python/fastquant/indicators/custom.py
+++ b/python/fastquant/indicators/custom.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+q#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Import standard library
 from __future__ import (
@@ -19,10 +19,9 @@ class CustomIndicator(bt.Indicator):
 
     """
     Custom Indicator
-    Implementation of sentiment custom indicator using nltk/textblob pre-built sentiment models
     """
 
-    lines = ("sentiment",)
+    lines = ("custom",)
 
     plotinfo = dict(
         plotymargin=0.15, plothlines=[0], plotyticks=[1.0, 0, -1.0]
@@ -45,4 +44,4 @@ class CustomIndicator(bt.Indicator):
         return
 
     def next(self):
-        self.lines.sentiment[0] = self.datas[0].sentiment_score[0]
+        self.lines.custom[0] = self.datas[0].custom[0]

--- a/python/fastquant/indicators/custom.py
+++ b/python/fastquant/indicators/custom.py
@@ -25,8 +25,8 @@ class CustomIndicator(bt.Indicator):
 
     params = (
         ("custom_column", "custom"),
-        ("upper_limit", 80),
-        ("lower_limit", 20),
+        ("upper_limit", 95),
+        ("lower_limit", 5),
     )
 
     plotlines = dict(

--- a/python/fastquant/indicators/custom.py
+++ b/python/fastquant/indicators/custom.py
@@ -42,18 +42,17 @@ class CustomIndicator(bt.Indicator):
         )
     )
 
+    plotinfo = dict(
+        plotymargin=0.15,
+        plothlines=[0],
+        plotyticks=[5, 95],
+    )
+
     def __init__(self):
+        super().__init__()
         self.custom_column = self.params.custom_column
         self.upper_limit = self.params.upper_limit
         self.lower_limit = self.params.lower_limit
-
-        # Plotting lines are based on the upper and lower limits
-        CustomIndicator.plotinfo = dict(
-            plotymargin=0.15,
-            plothlines=[0],
-            plotyticks=[self.upper_limit, self.lower_limit],
-        )
-        super().__init__()
 
     def _plotlabel(self):
         return

--- a/python/fastquant/indicators/custom.py
+++ b/python/fastquant/indicators/custom.py
@@ -43,7 +43,6 @@ class CustomIndicator(bt.Indicator):
     )
 
     def __init__(self):
-        super().__init__()
         self.custom_column = self.params.custom_column
         self.upper_limit = self.params.upper_limit
         self.lower_limit = self.params.lower_limit
@@ -54,6 +53,7 @@ class CustomIndicator(bt.Indicator):
             plothlines=[0],
             plotyticks=[self.upper_limit, self.lower_limit],
         )
+        super().__init__()
 
     def _plotlabel(self):
         return

--- a/python/fastquant/indicators/custom.py
+++ b/python/fastquant/indicators/custom.py
@@ -1,4 +1,4 @@
-q#!/usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Import standard library
 from __future__ import (

--- a/python/fastquant/indicators/custom.py
+++ b/python/fastquant/indicators/custom.py
@@ -25,8 +25,6 @@ class CustomIndicator(bt.Indicator):
 
     params = (
         ("custom_column", "custom"),
-        ("upper_limit", 95),
-        ("lower_limit", 5),
     )
 
     plotlines = dict(
@@ -51,8 +49,6 @@ class CustomIndicator(bt.Indicator):
     def __init__(self):
         super().__init__()
         self.custom_column = self.params.custom_column
-        self.upper_limit = self.params.upper_limit
-        self.lower_limit = self.params.lower_limit
 
     def _plotlabel(self):
         return

--- a/python/fastquant/indicators/custom.py
+++ b/python/fastquant/indicators/custom.py
@@ -50,7 +50,9 @@ class CustomIndicator(bt.Indicator):
 
         # Plotting lines are based on the upper and lower limits
         CustomIndicator.plotinfo = dict(
-            plotymargin=0.15, plothlines=[0], plotyticks=[self.upper_limit, self.lower_limit]
+            plotymargin=0.15,
+            plothlines=[0],
+            plotyticks=[self.upper_limit, self.lower_limit],
         )
 
     def _plotlabel(self):

--- a/python/fastquant/strategies/__init__.py
+++ b/python/fastquant/strategies/__init__.py
@@ -7,3 +7,4 @@ from fastquant.strategies.ma_crossover import SMACStrategy, EMACStrategy
 from fastquant.strategies.macd import MACDStrategy
 from fastquant.strategies.rsi import RSIStrategy
 from fastquant.strategies.sentiment import SentimentStrategy
+from fastquant.strategies.custom import CustomStrategy

--- a/python/fastquant/strategies/base.py
+++ b/python/fastquant/strategies/base.py
@@ -20,13 +20,9 @@ import numpy as np
 from collections.abc import Iterable
 import time
 
-# from fastquant.data import get_bt_news_sentiment
-from fastquant.indicators import Sentiment
-
 from fastquant.config import (
     INIT_CASH,
     COMMISSION_PER_TRANSACTION,
-    DATA_FORMAT_MAPPING,
     GLOBAL_PARAMS,
     BUY_PROP,
     SELL_PROP,

--- a/python/fastquant/strategies/custom.py
+++ b/python/fastquant/strategies/custom.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Import standard library
+# Strategy module for custom indicators input to backtest
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
+
+# Import modules
+import backtrader as bt
+
+# Import from package
+from fastquant.strategies.base import BaseStrategy
+
+
+class CustomStrategy(CustomStrategy):
+    """
+    Simple moving average crossover strategy
+
+    Parameters
+    ----------
+    upper : float
+        The upper value of the custom indicator above which, the asset is sold
+    lower : float
+        The lower value of the custom indicator above which, the asset is sold
+
+    """
+
+    params = (
+        ("upper", 80),  # period for the fast moving average
+        ("lower", 20),
+    )
+
+    def __init__(self):
+        # Initialize global variables
+        super().__init__()
+        # Strategy level variables
+        self.fast_period = self.params.fast_period
+        self.slow_period = self.params.slow_period
+
+        print("===Strategy level arguments===")
+        print("fast_period :", self.fast_period)
+        print("slow_period :", self.slow_period)
+        sma_fast = bt.ind.SMA(period=self.fast_period)  # fast moving average
+        sma_slow = bt.ind.SMA(period=self.slow_period)  # slow moving average
+        self.crossover = bt.ind.CrossOver(
+            sma_fast, sma_slow
+        )  # crossover signal
+
+    def buy_signal(self):
+        return self.crossover > 0
+
+    def sell_signal(self):
+        return self.crossover < 0

--- a/python/fastquant/strategies/custom.py
+++ b/python/fastquant/strategies/custom.py
@@ -52,9 +52,9 @@ class CustomStrategy(BaseStrategy):
         self.custom_indicator = CustomIndicator(
             self.data,
             custom_column=self.custom_column,
-            upper_limit=self.params.upper_limit,
-            lower_limit=self.params.lower_limit,
         )
+        # Plotting lines are based on the upper and lower limits
+        self.custom_indicator.plotinfo.plotyticks = [self.lower_limit, self.upper_limit]
 
         print("===Strategy level arguments===")
         print("Upper limit :", self.upper_limit)

--- a/python/fastquant/strategies/custom.py
+++ b/python/fastquant/strategies/custom.py
@@ -19,7 +19,9 @@ from fastquant.indicators.custom import CustomIndicator
 
 class CustomStrategy(BaseStrategy):
     """
-    Simple moving average crossover strategy
+    implements a chosen dataframe column as a custom indicator (column name set as "custom" by default).
+    
+    The strategy is structured similar to RSIStrategy where you can set an upper_limit, above which the asset is sold (considered "overbought"), and a lower_limit, below which the asset is sold (considered "underbought). upper_limit is set to 95 by default, while lower_limit is set to 5 by default.
 
     Parameters
     ----------

--- a/python/fastquant/strategies/custom.py
+++ b/python/fastquant/strategies/custom.py
@@ -43,7 +43,7 @@ class CustomStrategy(BaseStrategy):
         self.upper_limit = self.params.upper_limit
         self.lower_limit = self.params.lower_limit
         self.custom_column = self.params.custom_column
-        self.custom_indicator = CustomIndicator(self.data, self.custom_column)
+        self.custom_indicator = CustomIndicator(self.custom_column)
 
         print("===Strategy level arguments===")
         print("Upper limit :", self.upper_limit)

--- a/python/fastquant/strategies/custom.py
+++ b/python/fastquant/strategies/custom.py
@@ -14,9 +14,10 @@ import backtrader as bt
 
 # Import from package
 from fastquant.strategies.base import BaseStrategy
+from fastquant.indicators.custom import CustomIndicator
 
 
-class CustomStrategy(CustomStrategy):
+class CustomStrategy(BaseStrategy):
     """
     Simple moving average crossover strategy
 

--- a/python/fastquant/strategies/custom.py
+++ b/python/fastquant/strategies/custom.py
@@ -22,9 +22,9 @@ class CustomStrategy(CustomStrategy):
 
     Parameters
     ----------
-    upper : float
+    upper_limit : float
         The upper value of the custom indicator above which, the asset is sold
-    lower : float
+    lower_limit : float
         The lower value of the custom indicator above which, the asset is sold
 
     """
@@ -32,6 +32,7 @@ class CustomStrategy(CustomStrategy):
     params = (
         ("upper_limit", 80),  # period for the fast moving average
         ("lower_limit", 20),
+        ("custom_column", "custom"),
     )
 
     def __init__(self):
@@ -40,7 +41,8 @@ class CustomStrategy(CustomStrategy):
         # Strategy level variables
         self.upper_limit = self.params.upper_limit
         self.lower_limit = self.params.lower_limit
-        self.custom = self.lines.custom[0]
+        self.custom_column = self.params.custom_column
+        self.custom_indicator = CustomIndicator(self.data, self.custom_column)
 
         print("===Strategy level arguments===")
         print("Upper limit :", self.upper_limit)
@@ -48,7 +50,7 @@ class CustomStrategy(CustomStrategy):
 
     # Buy when the custom indicator is below the lower limit, and sell when it's above the upper limit
     def buy_signal(self):
-        return self.custom < self.lower_limit
+        return self.custom_indicator[0] < self.lower_limit
 
     def sell_signal(self):
-        return self.custom > self.upper_limit
+        return self.custom_indicator[0] > self.upper_limit

--- a/python/fastquant/strategies/custom.py
+++ b/python/fastquant/strategies/custom.py
@@ -27,17 +27,19 @@ class CustomStrategy(BaseStrategy):
         The upper value of the custom indicator above which, the asset is sold
     lower_limit : float
         The lower value of the custom indicator above which, the asset is sold
+    custom_column : str
+        The name of the column in the dataframe that corresponds to the custom indicator
 
     """
 
     params = (
-        ("upper_limit", 95),  # period for the fast moving average
+        ("upper_limit", 95),
         ("lower_limit", 5),
         ("custom_column", "custom"),
         (
             "type",
             "strength_index",
-        ),  # Plan to have modes: strength_index (like RSI), crossover (like SMAC), binary (just boolean)
+        ),  # Plan to have modes: strength_index (like RSI), crossover (like SMAC), binary (just sell, neutral, buy)
     )
 
     def __init__(self):

--- a/python/fastquant/strategies/custom.py
+++ b/python/fastquant/strategies/custom.py
@@ -31,8 +31,8 @@ class CustomStrategy(BaseStrategy):
     """
 
     params = (
-        ("upper_limit", 80),  # period for the fast moving average
-        ("lower_limit", 20),
+        ("upper_limit", 95),  # period for the fast moving average
+        ("lower_limit", 5),
         ("custom_column", "custom"),
         ("type", "strength_index"), # Plan to have modes: strength_index (like RSI), crossover (like SMAC), binary (just boolean)
     )

--- a/python/fastquant/strategies/custom.py
+++ b/python/fastquant/strategies/custom.py
@@ -63,8 +63,6 @@ class CustomStrategy(BaseStrategy):
     # Buy when the custom indicator is below the lower limit, and sell when it's above the upper limit
     def buy_signal(self):
         return self.custom_indicator[0] < self.lower_limit
-        # return getattr(self.datas[0], self.custom_column) < self.lower_limit
 
     def sell_signal(self):
         return self.custom_indicator[0] > self.upper_limit
-        # return getattr(self.datas[0], self.custom_column) > self.upper_limit

--- a/python/fastquant/strategies/custom.py
+++ b/python/fastquant/strategies/custom.py
@@ -34,7 +34,10 @@ class CustomStrategy(BaseStrategy):
         ("upper_limit", 95),  # period for the fast moving average
         ("lower_limit", 5),
         ("custom_column", "custom"),
-        ("type", "strength_index"), # Plan to have modes: strength_index (like RSI), crossover (like SMAC), binary (just boolean)
+        (
+            "type",
+            "strength_index",
+        ),  # Plan to have modes: strength_index (like RSI), crossover (like SMAC), binary (just boolean)
     )
 
     def __init__(self):
@@ -48,7 +51,7 @@ class CustomStrategy(BaseStrategy):
             self.data,
             custom_column=self.custom_column,
             upper_limit=self.params.upper_limit,
-            lower_limit=self.params.lower_limit
+            lower_limit=self.params.lower_limit,
         )
 
         print("===Strategy level arguments===")
@@ -58,8 +61,8 @@ class CustomStrategy(BaseStrategy):
     # Buy when the custom indicator is below the lower limit, and sell when it's above the upper limit
     def buy_signal(self):
         return self.custom_indicator[0] < self.lower_limit
-        #return getattr(self.datas[0], self.custom_column) < self.lower_limit
+        # return getattr(self.datas[0], self.custom_column) < self.lower_limit
 
     def sell_signal(self):
         return self.custom_indicator[0] > self.upper_limit
-        #return getattr(self.datas[0], self.custom_column) > self.upper_limit
+        # return getattr(self.datas[0], self.custom_column) > self.upper_limit

--- a/python/fastquant/strategies/custom.py
+++ b/python/fastquant/strategies/custom.py
@@ -30,28 +30,25 @@ class CustomStrategy(CustomStrategy):
     """
 
     params = (
-        ("upper", 80),  # period for the fast moving average
-        ("lower", 20),
+        ("upper_limit", 80),  # period for the fast moving average
+        ("lower_limit", 20),
     )
 
     def __init__(self):
         # Initialize global variables
         super().__init__()
         # Strategy level variables
-        self.fast_period = self.params.fast_period
-        self.slow_period = self.params.slow_period
+        self.upper_limit = self.params.upper_limit
+        self.lower_limit = self.params.lower_limit
+        self.custom = self.lines.custom[0]
 
         print("===Strategy level arguments===")
-        print("fast_period :", self.fast_period)
-        print("slow_period :", self.slow_period)
-        sma_fast = bt.ind.SMA(period=self.fast_period)  # fast moving average
-        sma_slow = bt.ind.SMA(period=self.slow_period)  # slow moving average
-        self.crossover = bt.ind.CrossOver(
-            sma_fast, sma_slow
-        )  # crossover signal
+        print("Upper limit :", self.upper_limit)
+        print("Lower limit :", self.lower_limit)
 
+    # Buy when the custom indicator is below the lower limit, and sell when it's above the upper limit
     def buy_signal(self):
-        return self.crossover > 0
+        return self.custom < self.lower_limit
 
     def sell_signal(self):
-        return self.crossover < 0
+        return self.custom > self.upper_limit

--- a/python/fastquant/strategies/custom.py
+++ b/python/fastquant/strategies/custom.py
@@ -34,6 +34,7 @@ class CustomStrategy(BaseStrategy):
         ("upper_limit", 80),  # period for the fast moving average
         ("lower_limit", 20),
         ("custom_column", "custom"),
+        ("type", "strength_index"), # Plan to have modes: strength_index (like RSI), crossover (like SMAC), binary (just boolean)
     )
 
     def __init__(self):
@@ -43,7 +44,12 @@ class CustomStrategy(BaseStrategy):
         self.upper_limit = self.params.upper_limit
         self.lower_limit = self.params.lower_limit
         self.custom_column = self.params.custom_column
-        self.custom_indicator = CustomIndicator(self.custom_column)
+        self.custom_indicator = CustomIndicator(
+            self.data,
+            custom_column=self.custom_column,
+            upper_limit=self.params.upper_limit,
+            lower_limit=self.params.lower_limit
+        )
 
         print("===Strategy level arguments===")
         print("Upper limit :", self.upper_limit)
@@ -52,6 +58,8 @@ class CustomStrategy(BaseStrategy):
     # Buy when the custom indicator is below the lower limit, and sell when it's above the upper limit
     def buy_signal(self):
         return self.custom_indicator[0] < self.lower_limit
+        #return getattr(self.datas[0], self.custom_column) < self.lower_limit
 
     def sell_signal(self):
         return self.custom_indicator[0] > self.upper_limit
+        #return getattr(self.datas[0], self.custom_column) > self.upper_limit

--- a/python/tests/test_strategies.py
+++ b/python/tests/test_strategies.py
@@ -27,7 +27,7 @@ def test_backtest():
 
     for strategy in STRATEGY_MAPPING.keys():
         if strategy == "sentiment":
-            data = get_yahoo_data("TSLA", "2020-01-01", "2020-02-01")
+            data = get_yahoo_data("TSLA", "2020-01-01", "2020-07-04")
             sentiments = get_bt_news_sentiment(keyword="tesla", page_nums=2)
             cerebro = backtest(
                 strategy, data, sentiments=sentiments, senti=0.4, plot=False

--- a/python/tests/test_strategies.py
+++ b/python/tests/test_strategies.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 from pathlib import Path
 from datetime import datetime
 from fastquant import (
@@ -20,14 +21,16 @@ def test_backtest():
     """
     Ensures that the backtest function works on all the registered strategies, with their default parameter values
     """
-    current_date = datetime.today().strftime("%Y-%m-%d")
     sample = pd.read_csv(SAMPLE_CSV, parse_dates=["dt"])
+    # Simulate custom indicator
+    sample["custom"] = np.random.random((sample.shape[0],)) * 100
+
     for strategy in STRATEGY_MAPPING.keys():
         if strategy == "sentiment":
-            data = get_yahoo_data("TSLA", "2020-01-01", current_date)
+            data = get_yahoo_data("TSLA", "2020-01-01", "2020-02-01")
             sentiments = get_bt_news_sentiment(keyword="tesla", page_nums=2)
             cerebro = backtest(
-                strategy, data, sentiments=sentiments, senti=0.4
+                strategy, data, sentiments=sentiments, senti=0.4, plot=False
             )
             errmsg = "Backtest encountered error for strategy '{}'!".format(
                 strategy


### PR DESCRIPTION
### This is an implementation to the most basic version of the ML / stat forecasting support w/ a custom indicator approach discussed in issue #168.

**Goal:** Users should be able to use forecasts (independent of stats / ML model used) as indicators to be used for backtesting

### Features of this PR

1. **Users can utilize a new `"custom"` strategy in `backtest` that implements a chosen dataframe column (`custom_column`) as a custom indicator (column name set as "custom" by default).**

The strategy is structured similar to `RSIStrategy` where you can set an `upper_limit`, above which the asset is sold (considered "overbought"), and a `lower_limit`, below which the asset is sold (considered "underbought). `upper_limit` is set to 95 by default, while `lower_limit` is set to 5 by default.

2. **New custom strategy (`CustomStrategy`), indicator (`CustomIndicator`), and data feed (`CustomData`)**

All three classes were designed to flexibly take in any column from the input dataframe as a feature. `CustomData` (which inherits from `PandasData`) is actually flexible enough to work on any column in the dataframe, and so I've decided to use it as the (universal) data feed for all fastquant strategies. `CustomData` also has dynamic data format handling by itself, which means that we can do away with the `infer_data_format` function (and the related constants) previously implemented. This means `data_format` is now deprecated, but I left it as an argument for now w/ a warning that it's no longer needed and we'll be taking it out in a coming release.

Lastly, this also means that adding new custom indicators & strategies later that require custom columns in the input dataframe will be a lot easier because `CustomData` now makes all of the dataframe's columns accessible automatically. No more need to make custom dataframe based data feeds! :smile:

3. **Testing was added for CustomStrategy using a randomized vector as a custom indicator**

Try it out with the example colab notebook [here](https://colab.research.google.com/drive/1MuouN-nH-b6hXTDi15QKlltQUkHkek3b?usp=sharing)! :grin: