### PR TITLE
Implement stop loss

### DIFF
--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -189,7 +189,12 @@ def backtest(
         )
         data = data.reset_index()
 
-    # If data has `dt` as the index and `dt` and `datetime` are not already columns, set `dt` as the first column
+    # If a `close` column exists but an `open` column doesn't, create a new `open` column with the same values as the `close` column
+    # This is for easier handling of next day trades (w/ the assumption that next day open is equal to current day close)
+    if "close" in data.columns and "open" not in data.columns:
+        data["open"] = data.close.values
+
+    # If data has `dt` as the index and `dt` or `datetime` are not already columns, set `dt` as the first column
     # This means `backtest` supports the dataframe whether `dt` is the index or a column
     if len(set(["dt", "datetime"]).intersection(data.columns)) == 0:
         if data.index.name == "dt":

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -192,7 +192,7 @@ def backtest(
     # If a `close` column exists but an `open` column doesn't, create a new `open` column with the same values as the `close` column
     # This is for easier handling of next day trades (w/ the assumption that next day open is equal to current day close)
     if "close" in data.columns and "open" not in data.columns:
-        data["open"] = data.close.values
+        data["open"] = data.close.shift().values
 
     # If data has `dt` as the index and `dt` or `datetime` are not already columns, set `dt` as the first column
     # This means `backtest` supports the dataframe whether `dt` is the index or a column

--- a/python/fastquant/strategies/base.py
+++ b/python/fastquant/strategies/base.py
@@ -43,6 +43,8 @@ class BaseStrategy(bt.Strategy):
         ("buy_prop", BUY_PROP),
         ("sell_prop", SELL_PROP),
         ("commission", COMMISSION_PER_TRANSACTION),
+        ("stop_loss", None),
+        ("stop_trail", None),
         (
             "execution_type",
             "close",
@@ -81,7 +83,8 @@ class BaseStrategy(bt.Strategy):
         self.transaction_logging = self.params.transaction_logging
         self.commission = self.params.commission
         self.channel = self.params.channel
-        self.symbol = self.params.symbol
+        self.stop_loss = self.params.stop_loss
+        self.stop_trail = self.params.stop_trail
         print("===Global level arguments===")
         print("init_cash : {}".format(self.init_cash))
         print("buy_prop : {}".format(self.buy_prop))
@@ -143,6 +146,14 @@ class BaseStrategy(bt.Strategy):
 
                 self.buyprice = order.executed.price
                 self.buycomm = order.executed.comm
+
+                if self.stop_loss:
+                    stop_price = order.executed.price * (1.0 - self.stop_loss)
+                    self.sell(exectype=bt.Order.Stop, price=stop_price)
+
+                if self.stop_trail:
+                    self.sell(exectype=bt.Order.StopTrail, trailamount=self.stop_trail)
+                    
             else:  # Sell
                 self.action = "sell"
                 if self.transaction_logging:

--- a/python/fastquant/strategies/base.py
+++ b/python/fastquant/strategies/base.py
@@ -257,13 +257,11 @@ class BaseStrategy(bt.Strategy):
                     if self.stop_loss:
                         stop_price = self.data.close[0] * (1.0 - self.stop_loss)
                         self.log("Stop price: {}".format(stop_price))
-                        #self.sell(exectype=bt.Order.Close, price=stop_price, size=final_size)
                         self.sell(exectype=bt.Order.Stop, price=stop_price, size=final_size)
 
                     if self.stop_trail:
                         self.log("Stop trail: {}".format(self.stop_trail))
-                        #self.sell(exectype=bt.Order.Close, trailamount=self.stop_trail, size=final_size)
-                        self.sell(exectype=bt.Order.StopTrail, trailamount=self.stop_trail, size=final_size)
+                        self.sell(exectype=bt.Order.StopTrail, trailpercent=self.stop_trail, size=final_size)
                         
 
                 # Buy based on the opening price of the next closing day (only works "open" data exists in the dataset)
@@ -288,7 +286,7 @@ class BaseStrategy(bt.Strategy):
 
                     if self.stop_trail:
                         self.log("Stop trail: {}".format(self.stop_trail))
-                        self.sell(exectype=bt.Order.StopTrail, trailamount=self.stop_trail, size=final_size)
+                        self.sell(exectype=bt.Order.StopTrail, trailpercent=self.stop_trail, size=final_size)
 
         elif self.sell_signal():
             if stock_value > 0:


### PR DESCRIPTION
### This PR implements stop loss and (partially) resolves issue #185.

Take note of the following details:

1. **`backtest` via `BaseStrategy` has two new arguments (set to `None` by default):** `stop_loss` and `stop_trail`.
2. **`stop_loss` means that you set the trigger price as a fixed percentage** of the price at which the asset was purchased (details [here](https://www.backtrader.com/blog/posts/2018-02-01-stop-trading/stop-trading/))
3. **`stop_trail` means that you apply a trailing percentage loss, that follows the price as it goes up** (details [here](https://www.backtrader.com/blog/posts/2018-02-01-stop-trading/stop-trading/))
4. **We now add a dummy "open" column to the input dataframe if a "close" column exists, but an "open" column doesn't.** This means we assume that when no open column exists, the next day open is equal to the current day close, which will be used as basis for the  m transaction. This also means that we can turn off the coc (cheat on close) setting, since it is now redundant as it is automatic in the case that no open column exists.
5. **The current implementation applies the stop sale regardless of whether you are still holding the asset** (short selling is allowed), and the default size of the transaction is the same size that was purchased during the original reference transaction. E.g., if you bought 100 shares of TSLA, then its stop loss will sell 100 shares of TSLA.

**Note:** I do understand that the short selling functionality goes against the current no short selling constraint, but once I realized it wasn't straightforward to implement this, I decided to implement stop loss in this way for now. We can more strictly apply the no short selling constraint to stop sales later. On another note, the risk of this happening is taken away in the case that we choose to derive sell signals solely from the stop logic. This can be a future feature to handle this.

@jpdeleon @rafmacalaba hoping you guys can review :smile: