### PR TITLE
Create Dockerfile for fastquant environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Set base image (host OS)
+FROM python:3.7
+
+# Set the working directory in the container
+WORKDIR /fastquant
+
+# Copy the dependencies file to the working directory
+COPY python/requirements.txt .
+
+# Install dependencies
+RUN pip install -r requirements.txt
+
+# Copy the content of the python directory to the working directory
+COPY python/ .

--- a/README.md
+++ b/README.md
@@ -303,3 +303,26 @@ Want to discuss more about fastquant with other users, and our team of developer
 Join the fastquant Slack community, and our bi-weekly remote meetups through this [link](https://join.slack.com/t/fastquant/shared_invite/zt-gaaoahkz-X~5qw0psNOLg1iFYKcpRlQ)!
 
 You can also [subscribe](https://forms.gle/HAPYdMp2YMu4qXPd7) to our monthly newsletter to receive updates on our latest tutorials, blog posts, and product features!
+
+## Run fastquant in a Docker Container
+
+```
+# Build the image
+docker build -t myimage .
+
+# Run the container
+docker run -t -d -p 5000:5000 myimage
+
+# Get the container id
+docker ps
+
+# SSH into the fastquant container
+docker exec -it <CONTAINER_ID> /bin/bash
+
+# Run python and use fastquant
+python
+
+>>> from fastquant import get_stock_data
+>>> df = get_stock_data("TSLA", "2019-01-01", "2020-01-01")
+>>> df.head()
+```


### PR DESCRIPTION
This PR creates a Dockerfile for fastquant which will make it easier to setup the package in different machines (resolving issue #242). 

A particular immediate use case is when fastquant has to be run, and eventually deployed on multiple servers. Personally, I'm already using this for running fastquant experiments in different VM's.