### PR TITLE
refactor get-stock-data to default in yf

### DIFF
--- a/python/fastquant/data/stocks/stocks.py
+++ b/python/fastquant/data/stocks/stocks.py
@@ -15,7 +15,9 @@ from fastquant.data.stocks.pse import get_pse_data
 from fastquant.data.stocks.yahoofinance import get_yahoo_data
 
 
-def get_stock_data(symbol, start_date, end_date, source="yahoo", format="c"):
+def get_stock_data(
+    symbol, start_date, end_date, source="yahoo", format="ohlcv"
+):
     """Returns pricing data for a specified stock and source.
 
     Parameters
@@ -45,10 +47,10 @@ def get_stock_data(symbol, start_date, end_date, source="yahoo", format="c"):
         # The query is run on 'yahoo', but if the symbol isn't found, the same query is run on 'phisix'.
         df = get_yahoo_data(symbol, start_date, end_date)
         if df is None:
-            df = get_pse_data(symbol, start_date, end_date, format=format)
+            df = get_pse_data(symbol, start_date, end_date, format="c")
     elif source == "phisix":
         # The query is run on 'phisix', but if the symbol isn't found, the same query is run on 'yahoo'.
-        df = get_pse_data(symbol, start_date, end_date, format=format)
+        df = get_pse_data(symbol, start_date, end_date, format="c")
         if df is None:
             df = get_yahoo_data(symbol, start_date, end_date)
     else:

--- a/python/fastquant/data/stocks/stocks.py
+++ b/python/fastquant/data/stocks/stocks.py
@@ -47,10 +47,10 @@ def get_stock_data(
         # The query is run on 'yahoo', but if the symbol isn't found, the same query is run on 'phisix'.
         df = get_yahoo_data(symbol, start_date, end_date)
         if df is None:
-            df = get_pse_data(symbol, start_date, end_date, format="c")
+            df = get_pse_data(symbol, start_date, end_date, format=format)
     elif source == "phisix":
         # The query is run on 'phisix', but if the symbol isn't found, the same query is run on 'yahoo'.
-        df = get_pse_data(symbol, start_date, end_date, format="c")
+        df = get_pse_data(symbol, start_date, end_date, format=format)
         if df is None:
             df = get_yahoo_data(symbol, start_date, end_date)
     else:

--- a/python/fastquant/data/stocks/stocks.py
+++ b/python/fastquant/data/stocks/stocks.py
@@ -15,7 +15,9 @@ from fastquant.data.stocks.pse import get_pse_data
 from fastquant.data.stocks.yahoofinance import get_yahoo_data
 
 
-def get_stock_data(symbol, start_date, end_date, source="yahoo"):
+def get_stock_data(
+    symbol, start_date, end_date, source="yahoo", format="ohlcv"
+):
     """Returns pricing data for a specified stock and source.
 
     Parameters
@@ -46,22 +48,20 @@ def get_stock_data(symbol, start_date, end_date, source="yahoo"):
         # The query is run on 'yahoo', but if the symbol isn't found, the same query is run on 'phisix'.
         df = get_yahoo_data(symbol, start_date, end_date)
         if df is None:
-            df = get_pse_data(symbol, start_date, end_date, format="c")
-            new_source = "phisix"
+            format = "c"
+            df = get_pse_data(symbol, start_date, end_date, format=format)
+
     elif source == "phisix":
         # The query is run on 'phisix', but if the symbol isn't found, the same query is run on 'yahoo'.
-        df = get_pse_data(symbol, start_date, end_date, format="c")
+        format = "c"
+        df = get_pse_data(symbol, start_date, end_date, format=format)
         if df is None:
             df = get_yahoo_data(symbol, start_date, end_date)
-            new_source = "yahoo"
+
     else:
         raise Exception("Source must be either 'phisix' or 'yahoo'")
 
-    if new_source == "yahoo":
-        df_columns = [DATA_FORMAT_COLS[c] for c in "ohlcv"]
-    else:
-        df_columns = [DATA_FORMAT_COLS[c] for c in "c"]
-
+    df_columns = [DATA_FORMAT_COLS[c] for c in format]
     missing_columns = [col for col in df_columns if col not in df.columns]
 
     # Fill missing columns with np.nan

--- a/python/fastquant/data/stocks/stocks.py
+++ b/python/fastquant/data/stocks/stocks.py
@@ -15,9 +15,7 @@ from fastquant.data.stocks.pse import get_pse_data
 from fastquant.data.stocks.yahoofinance import get_yahoo_data
 
 
-def get_stock_data(
-    symbol, start_date, end_date, source="yahoo", format="ohlcv"
-):
+def get_stock_data(symbol, start_date, end_date, source="yahoo"):
     """Returns pricing data for a specified stock and source.
 
     Parameters
@@ -44,19 +42,25 @@ def get_stock_data(
         Stock data (in the specified `format`) for the specified company and date range
     """
 
-    df_columns = [DATA_FORMAT_COLS[c] for c in format]
     if source == "yahoo":
         # The query is run on 'yahoo', but if the symbol isn't found, the same query is run on 'phisix'.
         df = get_yahoo_data(symbol, start_date, end_date)
         if df is None:
-            df = get_pse_data(symbol, start_date, end_date, format=format)
+            df = get_pse_data(symbol, start_date, end_date, format="c")
+            new_source = "phisix"
     elif source == "phisix":
         # The query is run on 'phisix', but if the symbol isn't found, the same query is run on 'yahoo'.
-        df = get_pse_data(symbol, start_date, end_date, format=format)
+        df = get_pse_data(symbol, start_date, end_date, format="c")
         if df is None:
             df = get_yahoo_data(symbol, start_date, end_date)
+            new_source = "yahoo"
     else:
         raise Exception("Source must be either 'phisix' or 'yahoo'")
+
+    if new_source == "yahoo":
+        df_columns = [DATA_FORMAT_COLS[c] for c in "ohlcv"]
+    else:
+        df_columns = [DATA_FORMAT_COLS[c] for c in "c"]
 
     missing_columns = [col for col in df_columns if col not in df.columns]
 

--- a/python/fastquant/data/stocks/stocks.py
+++ b/python/fastquant/data/stocks/stocks.py
@@ -15,7 +15,7 @@ from fastquant.data.stocks.pse import get_pse_data
 from fastquant.data.stocks.yahoofinance import get_yahoo_data
 
 
-def get_stock_data(symbol, start_date, end_date, source="yahoo"):
+def get_stock_data(symbol, start_date, end_date, source="yahoo", format="c"):
     """Returns pricing data for a specified stock and source.
 
     Parameters
@@ -45,10 +45,10 @@ def get_stock_data(symbol, start_date, end_date, source="yahoo"):
         # The query is run on 'yahoo', but if the symbol isn't found, the same query is run on 'phisix'.
         df = get_yahoo_data(symbol, start_date, end_date)
         if df is None:
-            df = get_pse_data(symbol, start_date, end_date, format="c")
+            df = get_pse_data(symbol, start_date, end_date, format=format)
     elif source == "phisix":
         # The query is run on 'phisix', but if the symbol isn't found, the same query is run on 'yahoo'.
-        df = get_pse_data(symbol, start_date, end_date, format="c")
+        df = get_pse_data(symbol, start_date, end_date, format=format)
         if df is None:
             df = get_yahoo_data(symbol, start_date, end_date)
     else:

--- a/python/fastquant/data/stocks/stocks.py
+++ b/python/fastquant/data/stocks/stocks.py
@@ -45,12 +45,12 @@ def get_stock_data(symbol, start_date, end_date, source="yahoo"):
         # The query is run on 'yahoo', but if the symbol isn't found, the same query is run on 'phisix'.
         df = get_yahoo_data(symbol, start_date, end_date)
         if df is None:
-            df = get_pse_data(symbol, start_date, end_date)
+            df = get_pse_data(symbol, start_date, end_date, format="c")
     elif source == "phisix":
         # The query is run on 'phisix', but if the symbol isn't found, the same query is run on 'yahoo'.
-        df = get_pse_data(symbol, start_date, end_date)
+        df = get_pse_data(symbol, start_date, end_date, format="c")
         if df is None:
-            df = get_yahoo_data(symbol, start_date, end_date, format="c")
+            df = get_yahoo_data(symbol, start_date, end_date)
     else:
         raise Exception("Source must be either 'phisix' or 'yahoo'")
 

--- a/python/fastquant/data/stocks/stocks.py
+++ b/python/fastquant/data/stocks/stocks.py
@@ -49,10 +49,10 @@ def get_stock_data(
         # The query is run on 'yahoo', but if the symbol isn't found, the same query is run on 'phisix'.
         df = get_yahoo_data(symbol, start_date, end_date)
         if df is None:
-            df = get_pse_data(symbol, start_date, end_date, format="c")
+            df = get_pse_data(symbol, start_date, end_date, format=format)
     elif source == "phisix":
         # The query is run on 'phisix', but if the symbol isn't found, the same query is run on 'yahoo'.
-        df = get_pse_data(symbol, start_date, end_date, format="c")
+        df = get_pse_data(symbol, start_date, end_date, format=format)
         if df is None:
             df = get_yahoo_data(symbol, start_date, end_date)
     else:

--- a/python/fastquant/data/stocks/stocks.py
+++ b/python/fastquant/data/stocks/stocks.py
@@ -35,6 +35,8 @@ def get_stock_data(
         First source to query from ("pse", "yahoo").
         If the stock is not found in the first source,
         the query is run on the other source.
+    format : str
+        Format of the output data
 
     Returns
     -------
@@ -47,10 +49,10 @@ def get_stock_data(
         # The query is run on 'yahoo', but if the symbol isn't found, the same query is run on 'phisix'.
         df = get_yahoo_data(symbol, start_date, end_date)
         if df is None:
-            df = get_pse_data(symbol, start_date, end_date, format=format)
+            df = get_pse_data(symbol, start_date, end_date, format="c")
     elif source == "phisix":
         # The query is run on 'phisix', but if the symbol isn't found, the same query is run on 'yahoo'.
-        df = get_pse_data(symbol, start_date, end_date, format=format)
+        df = get_pse_data(symbol, start_date, end_date, format="c")
         if df is None:
             df = get_yahoo_data(symbol, start_date, end_date)
     else:

--- a/python/fastquant/data/stocks/stocks.py
+++ b/python/fastquant/data/stocks/stocks.py
@@ -15,7 +15,7 @@ from fastquant.data.stocks.pse import get_pse_data
 from fastquant.data.stocks.yahoofinance import get_yahoo_data
 
 
-def get_stock_data(symbol, start_date, end_date, source="phisix", format="c"):
+def get_stock_data(symbol, start_date, end_date, source="yahoo"):
     """Returns pricing data for a specified stock and source.
 
     Parameters
@@ -33,8 +33,6 @@ def get_stock_data(symbol, start_date, end_date, source="phisix", format="c"):
         First source to query from ("pse", "yahoo").
         If the stock is not found in the first source,
         the query is run on the other source.
-    format : str
-        Format of the output data
 
     Returns
     -------
@@ -43,16 +41,16 @@ def get_stock_data(symbol, start_date, end_date, source="phisix", format="c"):
     """
 
     df_columns = [DATA_FORMAT_COLS[c] for c in format]
-    if source == "phisix":
-        # The query is run on 'phisix', but if the symbol isn't found, the same query is run on 'yahoo'.
-        df = get_pse_data(symbol, start_date, end_date, format=format)
-        if df is None:
-            df = get_yahoo_data(symbol, start_date, end_date)
-    elif source == "yahoo":
+    if source == "yahoo":
         # The query is run on 'yahoo', but if the symbol isn't found, the same query is run on 'phisix'.
         df = get_yahoo_data(symbol, start_date, end_date)
         if df is None:
             df = get_pse_data(symbol, start_date, end_date)
+    elif source == "phisix":
+        # The query is run on 'phisix', but if the symbol isn't found, the same query is run on 'yahoo'.
+        df = get_pse_data(symbol, start_date, end_date)
+        if df is None:
+            df = get_yahoo_data(symbol, start_date, end_date, format="c")
     else:
         raise Exception("Source must be either 'phisix' or 'yahoo'")
 

--- a/python/fastquant/portfolio.py
+++ b/python/fastquant/portfolio.py
@@ -56,7 +56,7 @@ class Portfolio:
     def get_data(self):
         dfs = []
         for i in self.stock_list:
-            df = get_stock_data(i, self.start_date, self.end_date)
+            df = get_stock_data(i, self.start_date, self.end_date, format="c")
             df.columns = [i]
             dfs.append(df)
         data = pd.concat(dfs, axis=1)

--- a/python/tests/test_fastquant.py
+++ b/python/tests/test_fastquant.py
@@ -15,7 +15,7 @@ DATE_END = "2019-01-01"
 
 
 def test_get_pse_data():
-    stock_df = get_pse_data(PHISIX_SYMBOL, DATE_START, DATE_END)
+    stock_df = get_pse_data(PHISIX_SYMBOL, DATE_START, DATE_END, format="c")
     assert isinstance(stock_df, pd.DataFrame)
 
 


### PR DESCRIPTION
just refactored get_stock_data to default in yahoo finance.

default format for yahoo data is `ohlcv` and if the ticker is not found in yf it goes to phisix with format of `c`

closes #235 