### PR TITLE
Add risk management analyzers

### DIFF
--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -167,6 +167,8 @@ def backtest(
     # Apply Total, Average, Compound and Annualized Returns calculated using a logarithmic approach
     cerebro.addanalyzer(btanalyzers.Returns, _name="returns")
     cerebro.addanalyzer(btanalyzers.SharpeRatio, _name="mysharpe")
+    cerebro.addanalyzer(btanalyzers.DrawDown, _name="drawdown")
+    cerebro.addanalyzer(btanalyzers.TimeDrawDown, _name="timedraw")
 
     cerebro.broker.setcommission(commission=commission)
 
@@ -328,6 +330,8 @@ def backtest(
         # We run metrics on the last strat since all the metrics will be the same for all strats
         returns = strat.analyzers.returns.get_analysis()
         sharpe = strat.analyzers.mysharpe.get_analysis()
+        drawdown = strat.analyzers.drawdown.get_analysis()
+        timedraw = strat.analyzers.timedraw.get_analysis()
         # Combine dicts for returns and sharpe
         m = {
             **returns,
@@ -343,6 +347,8 @@ def backtest(
             print(strats_params)
             print(returns)
             print(sharpe)
+            print(drawdown)
+            print(timedraw)
 
     params_df = pd.DataFrame(params)
     # Set the index as a separate strat id column, so that we retain the information after sorting

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -335,6 +335,8 @@ def backtest(
         # Combine dicts for returns and sharpe
         m = {
             **returns,
+            **drawdown,
+            **timedraw,
             **sharpe,
             "pnl": strat.pnl,
             "final_value": strat.final_value,


### PR DESCRIPTION
Resolves #254

Add risk metrics to backtesting results of backtests on trading stategies. This is an ongoing pull request for the following metrics:

1. Sharpe ratio - Measure of statistical significance of the return of investment given a risk free rate (default in package is 1%)
2. Drawdown - Measure of how low the asset price went before recovery relative to the overall price
3. Drawdown for a specified time period - Measure of the above within a time period specified by the user