### PR TITLE
Add indicator history to resolve #274

### DIFF
--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -282,7 +282,12 @@ def backtest(
         for i, strat in enumerate(stratrun):
             # Get indicator history
             indicators = strat.getindicators()
-            indicators_dict = {ind.plotlabel() if hasattr(ind, "plotlabel") else "indicator{}".format(i): ind.lines[0].array for i, ind in enumerate(indicators)}
+            indicators_dict = {
+                ind.plotlabel()
+                if hasattr(ind, "plotlabel")
+                else "indicator{}".format(i): ind.lines[0].array
+                for i, ind in enumerate(indicators)
+            }
             indicators_df = pd.DataFrame(indicators_dict)
             indicators_df.insert(0, "dt", data["datetime"].values)
 
@@ -435,7 +440,11 @@ def backtest(
         order_history = pd.concat(order_history_dfs)
         periodic_history = pd.concat(periodic_history_dfs)
         indicator_history = pd.concat(indicator_history_dfs)
-        history_dict = dict(orders=order_history, periodic=periodic_history, indicators=indicator_history)
+        history_dict = dict(
+            orders=order_history,
+            periodic=periodic_history,
+            indicators=indicator_history,
+        )
 
         return sorted_combined_df, history_dict
     else:

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -439,4 +439,4 @@ def backtest(
 
         return sorted_combined_df, history_dict
     else:
-        return sorted_combined_df, stratruns
+        return sorted_combined_df

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -282,7 +282,7 @@ def backtest(
         for i, strat in enumerate(stratrun):
             # Get indicator history
             indicators = strat.getindicators()
-            indicators_dict = {ind.plotlabel(): ind.lines[0].array for ind in indicators}
+            indicators_dict = {ind.plotlabel() if hasattr(ind, "plotlabel") else "indicator{}".format(i): ind.lines[0].array for i, ind in enumerate(indicators)}
             indicators_df = pd.DataFrame(indicators_dict)
             indicators_df.insert(0, "dt", data["datetime"].values)
 


### PR DESCRIPTION
## This PR adds the indicator history to the second `dict` output of `backtest` and resolves issues #274 and #216 .

*Note that it also includes the strat_id and strat_name fields, similar to the rest of the history dataframes.*

Sample usage:

```
from fastquant import get_stock_data, backtest

df = get_stock_data("TSLA", "2019-01-10", "2019-05-01")
res, hist = backtest("smac", df, return_history=True)

print(hist["indicators"])
```