### PR TITLE
Add periodic "income" feature to resolve #215

### DIFF
--- a/python/fastquant/strategies/base.py
+++ b/python/fastquant/strategies/base.py
@@ -57,8 +57,8 @@ class BaseStrategy(bt.Strategy):
         ("symbol", None),
         ("allow_short", False),
         ("short_max", SHORT_MAX),
-        ("freq", "* * * * *"),
-        ("income_amount", 10000)
+        ("add_cash_freq", "* * * * *"),
+        ("add_cash_amount", 10000)
     )
 
     def log(self, txt, dt=None):
@@ -94,8 +94,8 @@ class BaseStrategy(bt.Strategy):
         self.allow_short = self.params.allow_short
         self.short_max = self.params.short_max
         self.broker.set_coc(True)
-        self.freq = self.params.freq
-        self.income_amount = self.params.income_amount
+        self.add_cash_freq = self.params.add_cash_freq
+        self.add_cash_amount = self.params.add_cash_amount
         print("===Global level arguments===")
         print("init_cash : {}".format(self.init_cash))
         print("buy_prop : {}".format(self.buy_prop))
@@ -219,13 +219,15 @@ class BaseStrategy(bt.Strategy):
             )
 
     def start(self):
+        # Initialize income date iterator, and set next
         start_date = self.datas[0].datetime.date(0)
-        self.cron = croniter.croniter(self.freq, start_date)
+        self.cron = croniter.croniter(self.add_cash_freq, start_date)
         self.next_cash_datetime = self.cron.get_next(datetime.datetime)
 
     def next(self):
+        # Add cash to broker if date is equal to the next income date
         if self.datas[0].datetime.date(0) == self.next_cash_datetime:
-            self.broker.add_cash(self.income_amount)
+            self.broker.add_cash(self.add_cash_amount)
             self.next_cash_datetime = self.cron.get_next(datetime.datetime)
 
         self.update_periodic_history()

--- a/python/fastquant/strategies/base.py
+++ b/python/fastquant/strategies/base.py
@@ -20,6 +20,7 @@ import numpy as np
 from collections.abc import Iterable
 import time
 from fastquant.notification import trigger_bot
+import croniter
 
 from fastquant.config import (
     INIT_CASH,
@@ -54,8 +55,10 @@ class BaseStrategy(bt.Strategy):
         ("transaction_logging", True),
         ("channel", None),
         ("symbol", None),
-        ("allow_short", False), 
-        ("short_max", SHORT_MAX)
+        ("allow_short", False),
+        ("short_max", SHORT_MAX),
+        ("freq", "* * * * *"),
+        ("income_amount", 10000)
     )
 
     def log(self, txt, dt=None):
@@ -91,6 +94,8 @@ class BaseStrategy(bt.Strategy):
         self.allow_short = self.params.allow_short
         self.short_max = self.params.short_max
         self.broker.set_coc(True)
+        self.freq = self.params.freq
+        self.income_amount = self.params.income_amount
         print("===Global level arguments===")
         print("init_cash : {}".format(self.init_cash))
         print("buy_prop : {}".format(self.buy_prop))
@@ -154,7 +159,7 @@ class BaseStrategy(bt.Strategy):
 
                 self.buyprice = order.executed.price
                 self.buycomm = order.executed.comm
-                    
+
             else:  # Sell
                 self.action = "sell"
                 if self.transaction_logging:
@@ -213,7 +218,16 @@ class BaseStrategy(bt.Strategy):
                 self.symbol, self.action, last_date,
             )
 
+    def start(self):
+        start_date = self.datas[0].datetime.date(0)
+        cron = croniter.croniter(self.freq, start_date)
+        self.next_cash_datetime = cron.get_next(datetime.datetime)
+
     def next(self):
+        if self.datas[0].datetime.date(0) == self.next_cash_datetime:
+            self.broker.add_cash(self.income_amount)
+            self.next_cash_datetime = cron.get_next(datetime.datetime)
+
         self.update_periodic_history()
         if self.periodic_logging:
             self.log("Close, %.2f" % self.dataclose[0])
@@ -260,14 +274,23 @@ class BaseStrategy(bt.Strategy):
 
                     # Implement stop loss at the purchase level (only this specific trade is closed)
                     if self.stop_loss:
-                        stop_price = self.data.close[0] * (1.0 - self.stop_loss)
+                        stop_price = self.data.close[0] * (
+                            1.0 - self.stop_loss
+                        )
                         self.log("Stop price: {}".format(stop_price))
-                        self.sell(exectype=bt.Order.Stop, price=stop_price, size=final_size)
+                        self.sell(
+                            exectype=bt.Order.Stop,
+                            price=stop_price,
+                            size=final_size,
+                        )
 
                     if self.stop_trail:
                         self.log("Stop trail: {}".format(self.stop_trail))
-                        self.sell(exectype=bt.Order.StopTrail, trailpercent=self.stop_trail, size=final_size)
-                        
+                        self.sell(
+                            exectype=bt.Order.StopTrail,
+                            trailpercent=self.stop_trail,
+                            size=final_size,
+                        )
 
                 # Buy based on the opening price of the next closing day (only works "open" data exists in the dataset)
                 else:
@@ -285,13 +308,23 @@ class BaseStrategy(bt.Strategy):
 
                     # Implement stop loss at the purchase level (only this specific trade is closed)
                     if self.stop_loss:
-                        stop_price = self.data.close[0] * (1.0 - self.stop_loss)
+                        stop_price = self.data.close[0] * (
+                            1.0 - self.stop_loss
+                        )
                         self.log("Stop price: {}".format(stop_price))
-                        self.sell(exectype=bt.Order.Stop, price=stop_price, size=final_size)
+                        self.sell(
+                            exectype=bt.Order.Stop,
+                            price=stop_price,
+                            size=final_size,
+                        )
 
                     if self.stop_trail:
                         self.log("Stop trail: {}".format(self.stop_trail))
-                        self.sell(exectype=bt.Order.StopTrail, trailpercent=self.stop_trail, size=final_size)
+                        self.sell(
+                            exectype=bt.Order.StopTrail,
+                            trailpercent=self.stop_trail,
+                            size=final_size,
+                        )
 
         elif self.sell_signal():
             if self.allow_short == True:
@@ -299,33 +332,50 @@ class BaseStrategy(bt.Strategy):
                 # Sell short based on the closing price of the previous day
                 if self.execution_type == "close":
 
-
-                    sell_prop_size = int(SELL_PROP * 
-                                         self.broker.getvalue() / 
-                                         self.dataclose[1])
+                    sell_prop_size = int(
+                        SELL_PROP * self.broker.getvalue() / self.dataclose[1]
+                    )
                     # The max incremental short allowed is the short that would lead to a cumulative short position
                     # equal to the maximum short position (initial cash times the maximum short ratio, which is 1.5 by default)
-                    max_position_size = max(int(self.broker.getvalue() * self.short_max / self.dataclose[1]) + self.position.size, 0)
+                    max_position_size = max(
+                        int(
+                            self.broker.getvalue()
+                            * self.short_max
+                            / self.dataclose[1]
+                        )
+                        + self.position.size,
+                        0,
+                    )
                     if max_position_size > 0:
                         if self.transaction_logging:
                             self.log("SELL CREATE, %.2f" % self.dataclose[1])
-                        self.order = self.sell(size=min(sell_prop_size, max_position_size))
-                
-                 # Buy based on the opening price of the next closing day (only works "open" data exists in the dataset)
+                        self.order = self.sell(
+                            size=min(sell_prop_size, max_position_size)
+                        )
+
+                # Buy based on the opening price of the next closing day (only works "open" data exists in the dataset)
                 else:
 
-                    
-                    sell_prop_size = int(SELL_PROP * 
-                                         self.broker.getvalue() / 
-                                         self.dataopen[1])
+                    sell_prop_size = int(
+                        SELL_PROP * self.broker.getvalue() / self.dataopen[1]
+                    )
                     # The max incremental short allowed is the short that would lead to a cumulative short position
                     # equal to the maximum short position (initial cash times the maximum short ratio, which is 1.5 by default)
-                    max_position_size = max(int(self.broker.getvalue() * self.short_max / self.dataopen[1]) + self.position.size, 0)
+                    max_position_size = max(
+                        int(
+                            self.broker.getvalue()
+                            * self.short_max
+                            / self.dataopen[1]
+                        )
+                        + self.position.size,
+                        0,
+                    )
                     if max_position_size > 0:
                         if self.transaction_logging:
                             self.log("SELL CREATE, %.2f" % self.dataopen[1])
-                        self.order = self.sell(size=min(sell_prop_size, max_position_size))
-
+                        self.order = self.sell(
+                            size=min(sell_prop_size, max_position_size)
+                        )
 
             elif stock_value > 0:
 

--- a/python/fastquant/strategies/base.py
+++ b/python/fastquant/strategies/base.py
@@ -220,13 +220,13 @@ class BaseStrategy(bt.Strategy):
 
     def start(self):
         start_date = self.datas[0].datetime.date(0)
-        cron = croniter.croniter(self.freq, start_date)
-        self.next_cash_datetime = cron.get_next(datetime.datetime)
+        self.cron = croniter.croniter(self.freq, start_date)
+        self.next_cash_datetime = self.cron.get_next(datetime.datetime)
 
     def next(self):
         if self.datas[0].datetime.date(0) == self.next_cash_datetime:
             self.broker.add_cash(self.income_amount)
-            self.next_cash_datetime = cron.get_next(datetime.datetime)
+            self.next_cash_datetime = self.cron.get_next(datetime.datetime)
 
         self.update_periodic_history()
         if self.periodic_logging:

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,6 +5,7 @@ bs4==0.0.1
 ccxt==1.30.59
 certifi==2019.11.28
 chardet==3.0.4
+croniter==0.3.35
 idna==2.8
 lxml==4.4.2
 matplotlib==3.1.2


### PR DESCRIPTION
### This PR allows users to set periodic increases to their cash balance by utilizing `add_cash_amount` and `add_cash_freq`

**Details**
1. **`add_cash_amount` indicates the amount of cash you want to add to your portfolio at each "add cash date".** Once this cash balance is added, the same `buy_prop` will be used as basis for guiding position sizing for now.
2. **`add_cash_freq` indicates the frequency that you add cash.** Currently you can choose from monthly ("M"), on the first day of the month, weekly ("W"), on Monday, or a custom cron notation that indicates your cadence of choice (e.g. 0 0 5 * * for montly on the fifth day of the week).
3. **In the case that the next add cash date lies on a day not contained in the input time series** (e.g. a weekend), the algo will assume the cash inflow is added on the earliest next date (e.g. if the add cash date is Nov 1 which is a weekend, Sunday, with no data, the cash is added on the next weekday, Nov 2, Monday.