### PR TITLE
Refactor backtest components into: data preparation, metrics, and plotting

### DIFF
--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -42,6 +42,8 @@ from fastquant.config import (
     DEFAULT_PANDAS,
 )
 
+from fastquant.backtest.data_prep import initalize_data
+from fastquant.backtest.post_backtest import params_and_metrics, plot_results
 
 STRATEGY_MAPPING = {
     "rsi": RSIStrategy,
@@ -69,11 +71,6 @@ def docstring_parameter(*sub):
     return dec
 
 
-def tuple_to_dict(tup):
-    di = dict(tup)
-    return di
-
-
 @docstring_parameter(strat_docs)
 def backtest(
     strategy,
@@ -91,7 +88,8 @@ def backtest(
     symbol=None,
     allow_short=False,
     short_max=1.5,
-    **kwargs
+    figsize=(30, 15),
+    **kwargs,
 ):
     """Backtest financial data with a specified trading strategy
 
@@ -159,7 +157,7 @@ def backtest(
                 symbol=None,
                 allow_short=allow_short,
                 short_max=short_max,
-                **params
+                **params,
             )
             strat_names.append(strat)
     else:
@@ -179,7 +177,7 @@ def backtest(
             symbol=None,
             allow_short=allow_short,
             short_max=short_max,
-            **kwargs
+            **kwargs,
         )
         strat_names.append(strat_name)
 
@@ -191,72 +189,10 @@ def backtest(
 
     cerebro.broker.setcommission(commission=commission)
 
-    # Treat `data` as a path if it's a string; otherwise, it's treated as a pandas dataframe
-    if isinstance(data, str):
-        if verbose > 0:
-            print("Reading path as pandas dataframe ...")
-        # Rename dt to datetime
-        data = pd.read_csv(data, header=0, parse_dates=["dt"])
-
-    if strat_name == "sentiment":
-        # initialize series for sentiments
-        senti_series = pd.Series(
-            sentiments, name="sentiment_score", dtype=float
-        )
-
-        # join and reset the index for dt to become the first column
-        data = data.merge(
-            senti_series, left_index=True, right_index=True, how="left"
-        )
-        data = data.reset_index()
-
-    # If a `close` column exists but an `open` column doesn't, create a new `open` column with the same values as the `close` column
-    # This is for easier handling of next day trades (w/ the assumption that next day open is equal to current day close)
-    if "close" in data.columns and "open" not in data.columns:
-        data["open"] = data.close.shift().values
-
-    # If data has `dt` as the index and `dt` or `datetime` are not already columns, set `dt` as the first column
-    # This means `backtest` supports the dataframe whether `dt` is the index or a column
-    if len(set(["dt", "datetime"]).intersection(data.columns)) == 0:
-        if data.index.name == "dt":
-            data = data.reset_index()
-        # If the index is a datetime index, set this as the datetime column
-        elif isinstance(data.index, pd.DatetimeIndex):
-            data.index.name = "dt"
-            data = data.reset_index()
-
-    # Rename "dt" column to "datetime" to match the formal alias
-    data = data.rename(columns={"dt": "datetime"})
-    data["datetime"] = pd.to_datetime(data.datetime)
-
-    numeric_cols = [col for col in data.columns if is_numeric_dtype(data[col])]
-    params_tuple = tuple(
-        [
-            (col, i)
-            for i, col in enumerate(data.columns)
-            if col in numeric_cols + ["datetime"]
-        ]
+    # Initalize and verify data
+    pd_data, data, data_format_dict = initalize_data(
+        data, strat_name, sentiments
     )
-    default_cols = [c for c, _ in DEFAULT_PANDAS]
-    non_default_numeric_cols = tuple(
-        [col for col, _ in params_tuple if col not in default_cols]
-    )
-
-    class CustomData(bt.feeds.PandasData):
-        """
-        Data feed that includes all the columns in the input dataframe
-        """
-
-        # Need to make sure that the new lines don't overlap w/ the default lines already in PandasData
-        lines = non_default_numeric_cols
-
-        # automatically handle parameter with -1
-        # add the parameter to the parameters inherited from the base class
-        params = params_tuple
-
-    data_format_dict = tuple_to_dict(params_tuple)
-    pd_data = CustomData(dataname=data, **data_format_dict)
-
     cerebro.adddata(pd_data)
     cerebro.broker.setcash(init_cash)
     # Allows us to set buy price based on next day closing
@@ -276,163 +212,23 @@ def backtest(
         # print out the result
         print("Time used (seconds):", str(tend - tstart))
 
-    params = []
-    metrics = []
-    if verbose > 0:
-        print("==================================================")
-        print("Number of strat runs:", len(stratruns))
-        print("Number of strats per run:", len(stratruns[0]))
-        print("Strat names:", strat_names)
-
-    order_history_dfs = []
-    periodic_history_dfs = []
-    indicator_history_dfs = []
-    for strat_idx, stratrun in enumerate(stratruns):
-        strats_params = {}
-
-        if verbose > 0:
-            print("**************************************************")
-
-        for i, strat in enumerate(stratrun):
-            # Get indicator history
-            indicators = strat.getindicators()
-            indicators_dict = {
-                ind.plotlabel()
-                if hasattr(ind, "plotlabel")
-                else "indicator{}".format(i): ind.lines[0].array
-                for i, ind in enumerate(indicators)
-            }
-            indicators_df = pd.DataFrame(indicators_dict)
-            indicators_df.insert(0, "dt", data["datetime"].values)
-
-            strat_name = strat_names[i]
-            p_raw = strat.p._getkwargs()
-            p, selected_p = {}, {}
-            for k, v in p_raw.items():
-                if k not in [
-                    "strategy_logging",
-                    "periodic_logging",
-                    "transaction_logging",
-                ]:
-                    # Make sure the parameters are mapped to the corresponding strategy
-                    if strategy == "multi":
-                        key = (
-                            "{}.{}".format(strat_name, k)
-                            if k not in GLOBAL_PARAMS
-                            else k
-                        )
-                        # make key with format: e.g. smac.slow_period40_fast_period10
-                        if k in strats[strat_name]:
-                            selected_p[k] = v
-                        pkeys = "_".join(
-                            ["{}{}".format(*i) for i in selected_p.items()]
-                        )
-                        history_key = "{}.{}".format(strat_name, pkeys)
-                    else:
-                        key = k
-
-                        # make key with format: e.g. slow_period40_fast_period10
-                        if k in kwargs.keys():
-                            selected_p[k] = v
-                        history_key = "_".join(
-                            ["{}{}".format(*i) for i in selected_p.items()]
-                        )
-                    p[key] = v
-
-            strats_params = {**strats_params, **p}
-
-            if return_history:
-                # columns are decided in log method of BaseStrategy class in base.py
-                order_history_df = strat.order_history_df
-                order_history_df["dt"] = pd.to_datetime(order_history_df.dt)
-                # combine rows with identical index
-                # history_df = order_history_df.set_index('dt').dropna(how='all')
-                # history_dfs[history_key] = order_history_df.stack().unstack().astype(float)
-                order_history_df.insert(0, "strat_name", history_key)
-                order_history_df.insert(0, "strat_id", strat_idx)
-                order_history_dfs.append(order_history_df)
-
-                periodic_history_df = strat.periodic_history_df
-                periodic_history_df["dt"] = pd.to_datetime(
-                    periodic_history_df.dt
-                )
-                periodic_history_df.insert(0, "strat_name", history_key)
-                periodic_history_df.insert(0, "strat_id", strat_idx)
-                periodic_history_df[
-                    "return"
-                ] = periodic_history_df.portfolio_value.pct_change()
-                periodic_history_dfs.append(periodic_history_df)
-
-                indicators_df.insert(0, "strat_name", history_key)
-                indicators_df.insert(0, "strat_id", strat_idx)
-                indicator_history_dfs.append(indicators_df)
-
-        # We run metrics on the last strat since all the metrics will be the same for all strats
-        returns = strat.analyzers.returns.get_analysis()
-        sharpe = strat.analyzers.mysharpe.get_analysis()
-        drawdown = strat.analyzers.drawdown.get_analysis()
-        timedraw = strat.analyzers.timedraw.get_analysis()
-        # Combine dicts for returns and sharpe
-        m = {
-            **returns,
-            **drawdown,
-            **timedraw,
-            **sharpe,
-            "pnl": strat.pnl,
-            "final_value": strat.final_value,
-        }
-
-        params.append(strats_params)
-        metrics.append(m)
-        if verbose > 0:
-            print("--------------------------------------------------")
-            print_dict(strats_params, "Strategy Parameters")
-            print_dict(returns, "Returns")
-            print_dict(sharpe, "Sharpe")
-            print_dict(drawdown, "Drawdown")
-            print_dict(timedraw, "Timedraw")
-
-    params_df = pd.DataFrame(params)
-    # Set the index as a separate strat id column, so that we retain the information after sorting
-    strat_ids = pd.DataFrame({"strat_id": params_df.index.values})
-    metrics_df = pd.DataFrame(metrics)
-
-    # Get indices based on `sort_by` metric
-    optim_idxs = np.argsort(metrics_df[sort_by].values)[::-1]
-    sorted_params_df = params_df.iloc[optim_idxs].reset_index(drop=True)
-    sorted_metrics_df = metrics_df.iloc[optim_idxs].reset_index(drop=True)
-    sorted_strat_ids = strat_ids.iloc[optim_idxs].reset_index(drop=True)
-    sorted_combined_df = pd.concat(
-        [sorted_strat_ids, sorted_params_df, sorted_metrics_df], axis=1
+    # Get History, Optimal Parameters and Strategy Metrics
+    sorted_combined_df, optim_params, history_dict = params_and_metrics(
+        stratruns,
+        data,
+        strat_names,
+        strategy,
+        strats,
+        sort_by,
+        return_history,
+        verbose,
+        **kwargs,
     )
 
-    # Save optimal parameters as dictionary
-    optim_params = sorted_params_df.iloc[0].to_dict()
-    optim_metrics = sorted_metrics_df.iloc[0].to_dict()
-
-    if verbose > 0:
-        print_dict(optim_params, "Optimal parameters:")
-        print_dict(optim_metrics, "Optimal metrics:")
-
+    # Plot
     if plot and strategy != "multi":
-        has_volume = (
-            data_format_dict["volume"] is not None
-            if "volume" in data_format_dict.keys()
-            else False
-        )
         # Plot only with the optimal parameters when multiple strategy runs are required
-        if params_df.shape[0] == 1:
-            # This handles the Colab Plotting
-            # Simple Check if we are in Colab
-            try:
-                from google.colab import drive
-
-                iplot = False
-
-            except Exception:
-                iplot = True
-            cerebro.plot(volume=has_volume, figsize=(30, 15), iplot=iplot)
-        else:
+        if sorted_combined_df.shape[0] != 1:
             if verbose > 0:
                 print("=============================================")
                 print("Plotting backtest for optimal parameters ...")
@@ -442,46 +238,16 @@ def backtest(
                 plot=plot,
                 verbose=verbose,
                 sort_by=sort_by,
-                **optim_params
+                **optim_params,
             )
-    # drop extra columns #248
-    if (
-        len(
-            set(["channel" "symbol"]).intersection(
-                sorted_combined_df.columns.values
-            )
-        )
-        == 2
-    ):
-        sorted_combined_df.drop(["channel", "symbol"], axis=1, inplace=True)
+        else:
+            plot_results(cerebro, data_format_dict, figsize)
+
     if return_history:
-        order_history = pd.concat(order_history_dfs)
-        periodic_history = pd.concat(periodic_history_dfs)
-        indicator_history = pd.concat(indicator_history_dfs)
-        history_dict = dict(
-            orders=order_history,
-            periodic=periodic_history,
-            indicators=indicator_history,
-        )
 
         return sorted_combined_df, history_dict
     else:
         return sorted_combined_df
-
-
-def print_dict(d, title="", format="inline"):
-    if format is None:
-        print(title, d)
-
-    if format == "inline":
-        items = [title] + ["%s:%s" % (key, value) for key, value in d.items()]
-        print("\t".join(items))
-
-    if format == "indent":
-        if title != "":
-            print(title)
-        for key, value in d.items():
-            print("\t%s:%s" % (key, value))
 
 
 def get_logging_params(verbose):

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -19,20 +19,6 @@ from collections.abc import Iterable
 import time
 from pandas.api.types import is_numeric_dtype
 
-# Import from package
-from fastquant.strategies import (
-    RSIStrategy,
-    SMACStrategy,
-    BaseStrategy,
-    MACDStrategy,
-    EMACStrategy,
-    BBandsStrategy,
-    BuyAndHoldStrategy,
-    SentimentStrategy,
-    CustomStrategy,
-    TernaryStrategy,
-)
-
 
 # Import backtest variables
 from fastquant.config import (
@@ -41,22 +27,12 @@ from fastquant.config import (
     GLOBAL_PARAMS,
     DEFAULT_PANDAS,
 )
+from fastquant.strategies.mappings import STRATEGY_MAPPING
 
+# Other backtest components
 from fastquant.backtest.data_prep import initalize_data
 from fastquant.backtest.post_backtest import params_and_metrics, plot_results
 
-STRATEGY_MAPPING = {
-    "rsi": RSIStrategy,
-    "smac": SMACStrategy,
-    "base": BaseStrategy,
-    "macd": MACDStrategy,
-    "emac": EMACStrategy,
-    "bbands": BBandsStrategy,
-    "buynhold": BuyAndHoldStrategy,
-    "sentiment": SentimentStrategy,
-    "custom": CustomStrategy,
-    "ternary": TernaryStrategy,
-}
 
 strat_docs = "\nExisting strategies:\n\n" + "\n".join(
     [key + "\n" + value.__doc__ for key, value in STRATEGY_MAPPING.items()]
@@ -145,6 +121,7 @@ def backtest(
     logging_params = get_logging_params(verbose)
     kwargs.update(logging_params)
 
+    # Add Strategy
     strat_names = []
     strat_name = None
     if strategy == "multi" and strats is not None:
@@ -234,9 +211,9 @@ def backtest(
                 print("Plotting backtest for optimal parameters ...")
             backtest(
                 strategy,
-                data,  # Treated as csv path is str, and dataframe of pd.DataFrame
+                data,
                 plot=plot,
-                verbose=verbose,
+                verbose=0,
                 sort_by=sort_by,
                 **optim_params,
             )

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -31,7 +31,7 @@ from fastquant.strategies.mappings import STRATEGY_MAPPING
 
 # Other backtest components
 from fastquant.backtest.data_prep import initalize_data
-from fastquant.backtest.post_backtest import params_and_metrics, plot_results
+from fastquant.backtest.post_backtest import analyze_strategies, plot_results
 
 
 strat_docs = "\nExisting strategies:\n\n" + "\n".join(
@@ -190,7 +190,7 @@ def backtest(
         print("Time used (seconds):", str(tend - tstart))
 
     # Get History, Optimal Parameters and Strategy Metrics
-    sorted_combined_df, optim_params, history_dict = params_and_metrics(
+    sorted_combined_df, optim_params, history_dict = analyze_strategies(
         stratruns,
         data,
         strat_names,

--- a/python/fastquant/backtest/data_prep.py
+++ b/python/fastquant/backtest/data_prep.py
@@ -1,0 +1,86 @@
+import pandas as pd
+import backtrader as bt
+from pandas.api.types import is_numeric_dtype
+
+
+from fastquant.config import DEFAULT_PANDAS
+
+
+def initalize_data(data, strategy_name, sentiments=None):
+
+    # Treat `data` as a path if it's a string; otherwise, it's treated as a pandas dataframe
+    if isinstance(data, str):
+        if verbose > 0:
+            print("Reading path as pandas dataframe ...")
+        # Rename dt to datetime
+        data = pd.read_csv(data, header=0, parse_dates=["dt"])
+
+    if strategy_name == "sentiment":
+        data = include_sentiment_score(data, sentiments)
+
+    # If a `close` column exists but an `open` column doesn't, create a new `open` column with the same values as the `close` column
+    # This is for easier handling of next day trades (w/ the assumption that next day open is equal to current day close)
+    if "close" in data.columns and "open" not in data.columns:
+        data["open"] = data.close.shift().values
+
+    # If data has `dt` as the index and `dt` or `datetime` are not already columns, set `dt` as the first column
+    # This means `backtest` supports the dataframe whether `dt` is the index or a column
+    if len(set(["dt", "datetime"]).intersection(data.columns)) == 0:
+        if data.index.name == "dt":
+            data = data.reset_index()
+        # If the index is a datetime index, set this as the datetime column
+        elif isinstance(data.index, pd.DatetimeIndex):
+            data.index.name = "dt"
+            data = data.reset_index()
+
+    # Rename "dt" column to "datetime" to match the formal alias
+    data = data.rename(columns={"dt": "datetime"})
+    data["datetime"] = pd.to_datetime(data.datetime)
+
+    numeric_cols = [col for col in data.columns if is_numeric_dtype(data[col])]
+    params_tuple = tuple(
+        [
+            (col, i)
+            for i, col in enumerate(data.columns)
+            if col in numeric_cols + ["datetime"]
+        ]
+    )
+    default_cols = [c for c, _ in DEFAULT_PANDAS]
+    non_default_numeric_cols = tuple(
+        [col for col, _ in params_tuple if col not in default_cols]
+    )
+
+    class CustomData(bt.feeds.PandasData):
+        """
+        Data feed that includes all the columns in the input dataframe
+        """
+
+        # Need to make sure that the new lines don't overlap w/ the default lines already in PandasData
+        lines = non_default_numeric_cols
+
+        # automatically handle parameter with -1
+        # add the parameter to the parameters inherited from the base class
+        params = params_tuple
+
+    data_format_dict = tuple_to_dict(params_tuple)
+    pd_data = CustomData(dataname=data, **data_format_dict)
+
+    return pd_data, data, data_format_dict
+
+
+def include_sentiment_score(data, sentiments):
+
+    # initialize series for sentiments
+    senti_series = pd.Series(sentiments, name="sentiment_score", dtype=float)
+
+    # join and reset the index for dt to become the first column
+    data = data.merge(
+        senti_series, left_index=True, right_index=True, how="left"
+    )
+    data = data.reset_index()
+    return data
+
+
+def tuple_to_dict(tup):
+    di = dict(tup)
+    return di

--- a/python/fastquant/backtest/post_backtest.py
+++ b/python/fastquant/backtest/post_backtest.py
@@ -13,7 +13,7 @@ Post backtest functionalities
 """
 
 
-def params_and_metrics(
+def analyze_strategies(
     stratruns,
     data,
     strat_names,

--- a/python/fastquant/backtest/post_backtest.py
+++ b/python/fastquant/backtest/post_backtest.py
@@ -1,0 +1,246 @@
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+
+from fastquant.config import GLOBAL_PARAMS
+
+"""
+Post backtest functionalities
+- Retrieval of hisotry of orders, indicators and perodic logs
+- Analysis of each strategy
+- Plotting
+ 
+"""
+
+
+def params_and_metrics(
+    stratruns,
+    data,
+    strat_names,
+    strategy,
+    strats,
+    sort_by,
+    return_history,
+    verbose,
+    **kwargs
+):
+    params = []
+    metrics = []
+    if verbose > 0:
+        print("==================================================")
+        print("Number of strat runs:", len(stratruns))
+        print("Number of strats per run:", len(stratruns[0]))
+        print("Strat names:", strat_names)
+
+    order_history_dfs = []
+    periodic_history_dfs = []
+    indicator_history_dfs = []
+    for strat_idx, stratrun in enumerate(stratruns):
+        strats_params = {}
+
+        if verbose > 0:
+            print("**************************************************")
+
+        for i, strat in enumerate(stratrun):
+            # Get indicator history
+            indicators = strat.getindicators()
+            indicators_dict = {
+                ind.plotlabel()
+                if hasattr(ind, "plotlabel")
+                else "indicator{}".format(i): ind.lines[0].array
+                for i, ind in enumerate(indicators)
+            }
+            indicators_df = pd.DataFrame(indicators_dict)
+            indicators_df.insert(0, "dt", data["datetime"].values)
+
+            strat_name = strat_names[i]
+            p_raw = strat.p._getkwargs()
+            p, selected_p = {}, {}
+            for k, v in p_raw.items():
+                if k not in [
+                    "strategy_logging",
+                    "periodic_logging",
+                    "transaction_logging",
+                ]:
+                    # Make sure the parameters are mapped to the corresponding strategy
+                    if strategy == "multi":
+                        key = (
+                            "{}.{}".format(strat_name, k)
+                            if k not in GLOBAL_PARAMS
+                            else k
+                        )
+                        # make key with format: e.g. smac.slow_period40_fast_period10
+                        if k in strats[strat_name]:
+                            selected_p[k] = v
+                        pkeys = "_".join(
+                            ["{}{}".format(*i) for i in selected_p.items()]
+                        )
+                        history_key = "{}.{}".format(strat_name, pkeys)
+                    else:
+                        key = k
+
+                        # make key with format: e.g. slow_period40_fast_period10
+                        if k in kwargs.keys():
+                            selected_p[k] = v
+                        history_key = "_".join(
+                            ["{}{}".format(*i) for i in selected_p.items()]
+                        )
+                    p[key] = v
+
+            strats_params = {**strats_params, **p}
+
+            if return_history:
+                # columns are decided in log method of BaseStrategy class in base.py
+                order_history_df = strat.order_history_df
+                order_history_df["dt"] = pd.to_datetime(order_history_df.dt)
+                # combine rows with identical index
+                # history_df = order_history_df.set_index('dt').dropna(how='all')
+                # history_dfs[history_key] = order_history_df.stack().unstack().astype(float)
+                order_history_df.insert(0, "strat_name", history_key)
+                order_history_df.insert(0, "strat_id", strat_idx)
+                order_history_dfs.append(order_history_df)
+
+                periodic_history_df = strat.periodic_history_df
+                periodic_history_df["dt"] = pd.to_datetime(
+                    periodic_history_df.dt
+                )
+                periodic_history_df.insert(0, "strat_name", history_key)
+                periodic_history_df.insert(0, "strat_id", strat_idx)
+                periodic_history_df[
+                    "return"
+                ] = periodic_history_df.portfolio_value.pct_change()
+                periodic_history_dfs.append(periodic_history_df)
+
+                indicators_df.insert(0, "strat_name", history_key)
+                indicators_df.insert(0, "strat_id", strat_idx)
+                indicator_history_dfs.append(indicators_df)
+
+        # We run metrics on the last strat since all the metrics will be the same for all strats
+        returns = strat.analyzers.returns.get_analysis()
+        sharpe = strat.analyzers.mysharpe.get_analysis()
+        drawdown = strat.analyzers.drawdown.get_analysis()
+        timedraw = strat.analyzers.timedraw.get_analysis()
+        # Combine dicts for returns and sharpe
+        m = {
+            **returns,
+            **drawdown,
+            **timedraw,
+            **sharpe,
+            "pnl": strat.pnl,
+            "final_value": strat.final_value,
+        }
+
+        params.append(strats_params)
+        metrics.append(m)
+        if verbose > 0:
+            print("--------------------------------------------------")
+            print_dict(strats_params, "Strategy Parameters")
+            print_dict(returns, "Returns")
+            print_dict(sharpe, "Sharpe")
+            print_dict(drawdown, "Drawdown")
+            print_dict(timedraw, "Timedraw")
+
+    params_df = pd.DataFrame(params)
+    # Set the index as a separate strat id column, so that we retain the information after sorting
+    strat_ids = pd.DataFrame({"strat_id": params_df.index.values})
+    metrics_df = pd.DataFrame(metrics)
+
+    # Find optimal parameters
+    sorted_combined_df, optim_params = sort_metrics_params_and_strats(
+        metrics_df, params_df, strat_ids, sort_by, verbose
+    )
+
+    # History dict
+    if return_history:
+        order_history = pd.concat(order_history_dfs)
+        periodic_history = pd.concat(periodic_history_dfs)
+        indicator_history = pd.concat(indicator_history_dfs)
+        history_dict = dict(
+            orders=order_history,
+            periodic=periodic_history,
+            indicators=indicator_history,
+        )
+    else:
+        history_dict = dict()
+
+    return sorted_combined_df, optim_params, history_dict
+
+
+def sort_metrics_params_and_strats(
+    metrics_df, params_df, strat_ids, sort_by, verbose
+):
+
+    # Get indices based on `sort_by` metric
+    optim_idxs = np.argsort(metrics_df[sort_by].values)[::-1]
+    sorted_params_df = params_df.iloc[optim_idxs].reset_index(drop=True)
+    sorted_metrics_df = metrics_df.iloc[optim_idxs].reset_index(drop=True)
+    sorted_strat_ids = strat_ids.iloc[optim_idxs].reset_index(drop=True)
+    sorted_combined_df = pd.concat(
+        [sorted_strat_ids, sorted_params_df, sorted_metrics_df], axis=1
+    )
+
+    optim_params = get_optim_metrics_and_params(
+        sorted_metrics_df, sorted_params_df, verbose
+    )
+    # drop extra columns #248
+    if (
+        len(
+            set(["channel" "symbol"]).intersection(
+                sorted_combined_df.columns.values
+            )
+        )
+        == 2
+    ):
+        sorted_combined_df.drop(["channel", "symbol"], axis=1, inplace=True)
+
+    return sorted_combined_df, optim_params
+
+
+def get_optim_metrics_and_params(sorted_metrics_df, sorted_params_df, verbose):
+    # Save optimal parameters as dictionary
+    optim_params = sorted_params_df.iloc[0].to_dict()
+    optim_metrics = sorted_metrics_df.iloc[0].to_dict()
+
+    if verbose > 0:
+        print_dict(optim_params, "Optimal parameters:")
+        print_dict(optim_metrics, "Optimal metrics:")
+
+    return optim_params
+
+
+def plot_results(cerebro, data_format_dict, figsize=(30, 15)):
+
+    try:
+        # This handles the Colab Plotting, Simple Check if we are in Colab
+        from google.colab import drive
+
+        iplot = False
+    except Exception:
+        iplot = True
+
+    has_volume = (
+        data_format_dict["volume"] is not None
+        if "volume" in data_format_dict.keys()
+        else False
+    )
+
+    # Set matplotlib parameters
+    plt.style.use("classic")  # ggplot is also fine
+    plt.rcParams["figure.figsize"] = figsize
+
+    cerebro.plot(volume=has_volume, iplot=iplot)
+
+
+def print_dict(d, title="", format="inline"):
+    if format is None:
+        print(title, d)
+
+    if format == "inline":
+        items = [title] + ["%s:%s" % (key, value) for key, value in d.items()]
+        print("\t".join(items))
+
+    if format == "indent":
+        if title != "":
+            print(title)
+        for key, value in d.items():
+            print("\t%s:%s" % (key, value))

--- a/python/fastquant/indicators/backtrader_indicators.py
+++ b/python/fastquant/indicators/backtrader_indicators.py
@@ -12,6 +12,8 @@ from __future__ import (
 from backtrader.indicators import (
     AverageDirectionalMovementIndex,
     ADX,
+    AverageTrueRange,
+    ATR,
     BollingerBands,
     BBands,
     CommodityChannelIndex,
@@ -21,6 +23,7 @@ from backtrader.indicators import (
     EMA,
     Ichimoku,
     MACD,
+    ParabolicSAR,
     RelativeStrengthIndex,
     RSI,
     SimpleMovingAverage,

--- a/python/fastquant/strategies/mappings.py
+++ b/python/fastquant/strategies/mappings.py
@@ -1,0 +1,27 @@
+# Import from package
+from fastquant.strategies import (
+    RSIStrategy,
+    SMACStrategy,
+    BaseStrategy,
+    MACDStrategy,
+    EMACStrategy,
+    BBandsStrategy,
+    BuyAndHoldStrategy,
+    SentimentStrategy,
+    CustomStrategy,
+    TernaryStrategy,
+)
+
+# Register your strategy here
+STRATEGY_MAPPING = {
+    "rsi": RSIStrategy,
+    "smac": SMACStrategy,
+    "base": BaseStrategy,
+    "macd": MACDStrategy,
+    "emac": EMACStrategy,
+    "bbands": BBandsStrategy,
+    "buynhold": BuyAndHoldStrategy,
+    "sentiment": SentimentStrategy,
+    "custom": CustomStrategy,
+    "ternary": TernaryStrategy,
+}

--- a/python/tests/test_strategies.py
+++ b/python/tests/test_strategies.py
@@ -46,7 +46,7 @@ def test_backtest():
             assert cerebro is not None, errmsg
 
             data_disclosures = get_stock_data(
-                "JFC", "2020-01-01", "2020-09-30", source="phisix"
+                "TSLA", "2020-01-01", "2020-09-30",  # source="phisix"
             )
 
             # sentiments_disclosures = get_disclosure_sentiment(
@@ -65,10 +65,8 @@ def test_backtest():
                 senti=0.2,
                 plot=False,
             )
-            errmsg_disclosures = (
-                "Backtest encountered error for strategy '{}'!".format(
-                    strategy
-                )
+            errmsg_disclosures = "Backtest encountered error for strategy '{}'!".format(
+                strategy
             )
             assert cerebro_disclosures is not None, errmsg_disclosures
 


### PR DESCRIPTION
- Added `figsize` to backtest to adjust plot
- This will allow `backtest()` to focus more on strategies,  analyzers, and performance improvements  
- Moved the following components into a separate file: (data preparation, metrics, plotting)

## Data Preparation
- To add data validation here
- Allow fine tuning data

## Metrics
- This handles metrics and parameters for strategy optmization

## Plotting
- Separated end-of-backtest plotting logic outside the `backtesting` functionality 