### PR TITLE
Updated indicator history to support multiple lines

### DIFF
--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -141,7 +141,11 @@ def backtest(
 
         # Allow instance of BaseStrategy or from the predefined mapping
         if not isinstance(strategy, str) and issubclass(strategy, bt.Strategy):
-            strat_name = str(strategy)
+            strat_name = (
+                strategy.__name__
+                if hasattr(strategy, "__name__")
+                else str(strategy)
+            )
         else:
             strat_name = strategy
             strategy = STRATEGY_MAPPING[strategy]

--- a/python/fastquant/backtest/backtest_indicators.py
+++ b/python/fastquant/backtest/backtest_indicators.py
@@ -1,0 +1,86 @@
+from backtrader.indicators import (
+    BBands,
+    BollingerBands,
+    MACD,
+    MACDHisto,
+    MACDHistogram,
+    Envelope,
+    Ichimoku,
+    ADXR,
+    AverageDirectionalMovementIndexRating,
+)
+import re
+
+# Some indicators contain multiple "lines" instead of just one
+# From source code `lines` attribute of the indacator
+# https://github.com/mementum/backtrader/tree/master/backtrader/indicators
+multi_line_indicators = [
+    (AverageDirectionalMovementIndexRating, ("adx", "adxr",)),
+    (ADXR, ("adx", "adxr",)),
+    (BollingerBands, ("mid", "top", "bot",)),
+    (BBands, ("mid", "top", "bot",)),
+    (Envelope, ("top", "bot",)),
+    (MACD, ("macd", "signal",)),
+    (MACDHistogram, ("macd", "signal", "histo",)),
+    (MACDHisto, ("macd", "signal", "histo",)),
+    (
+        Ichimoku,
+        (
+            "tenkan_sen",
+            "kijun_sen",
+            "senkou_span_a",
+            "senkou_span_b",
+            "chikou_span",
+        ),
+    ),
+]
+
+
+indicator_regex = re.compile("[a-zA-Z0-9.]+")
+
+
+def get_indicators_as_dict(strat_run):
+    """
+    Returns the indicators used for the strategy run
+    """
+    indicators = strat_run.getindicators()
+    indicators_dict = dict()
+    for i, ind in enumerate(indicators):
+        indicator_name = (
+            ind.plotlabel()
+            if hasattr(ind, "plotlabel")
+            else "indicator{}".format(i)
+        )
+
+        # Check if indicator contains multiple lines
+        line_names = get_line_names(ind)
+        if len(line_names) > 1:
+            for lx, line_name in enumerate(line_names):
+                key = rename_indicator(indicator_name, line_name)
+                indicators_dict[key] = ind.lines[lx].array
+
+        else:
+            key = rename_indicator(indicator_name)
+            indicators_dict[key] = ind.lines[0].array
+
+    return indicators_dict
+
+
+def get_line_names(indicator):
+
+    for indicator_class, line_names in multi_line_indicators:
+        # Check the type/class # isinstance doesnt work on subclasses correctly
+        if type(indicator) == indicator_class:
+            return line_names
+    return ()
+
+
+def rename_indicator(name, line_name=None):
+    # Changes the name to <indicator>_<line>_<param1>_<param2>
+    tokens = indicator_regex.findall(name)
+    if line_name:
+        tokens = [tokens[0], line_name] + (
+            tokens[1:] if len(tokens) > 1 else []
+        )
+    return "_".join(tokens)
+

--- a/python/fastquant/backtest/post_backtest.py
+++ b/python/fastquant/backtest/post_backtest.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 
+from fastquant.backtest.backtest_indicators import get_indicators_as_dict
 from fastquant.config import GLOBAL_PARAMS
 
 """
@@ -43,13 +44,7 @@ def analyze_strategies(
 
         for i, strat in enumerate(stratrun):
             # Get indicator history
-            indicators = strat.getindicators()
-            indicators_dict = {
-                ind.plotlabel()
-                if hasattr(ind, "plotlabel")
-                else "indicator{}".format(i): ind.lines[0].array
-                for i, ind in enumerate(indicators)
-            }
+            indicators_dict = get_indicators_as_dict(strat)
             indicators_df = pd.DataFrame(indicators_dict)
             indicators_df.insert(0, "dt", data["datetime"].values)
 

--- a/python/fastquant/indicators/backtrader_indicators.py
+++ b/python/fastquant/indicators/backtrader_indicators.py
@@ -12,6 +12,8 @@ from __future__ import (
 from backtrader.indicators import (
     AverageDirectionalMovementIndex,
     ADX,
+    AverageDirectionalMovementIndexRating,
+    ADXR,
     AverageTrueRange,
     ATR,
     BollingerBands,
@@ -19,6 +21,7 @@ from backtrader.indicators import (
     CommodityChannelIndex,
     CCI,
     CrossOver,
+    Envelope,
     ExponentialMovingAverage,
     EMA,
     Ichimoku,


### PR DESCRIPTION
History of indicators can now support multiple lines.
Indicators like `BollingerBands` will have three lines instead of one
`BollingerBands_mid_20_0.2`
`BollingerBands_top_20_0.2`
`BollingerBands_bot_20_0.2`


Multi-line indicator support is listed in `python/fastquant/backtest/backtest_indicators.py`
