### PR TITLE
Add custom data_class to resolve #297

### DIFF
--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -65,6 +65,7 @@ def backtest(
     allow_short=False,
     short_max=1.5,
     figsize=(30, 15),
+    data_class=None,
     **kwargs,
 ):
     """Backtest financial data with a specified trading strategy
@@ -95,6 +96,8 @@ def backtest(
         Verbose can take values: [0, 1, 2, 3], with increasing levels of verbosity (default=1).
     symbol : str
         Symbol to be referenced in the channel notification if not None (default=None)
+    data_class : bt.feed.DataBase
+        Custom backtrader database to be used as a parent class instead bt.feed. (default=None)
     {0}
     """
 
@@ -168,7 +171,7 @@ def backtest(
 
     # Initalize and verify data
     pd_data, data, data_format_dict = initalize_data(
-        data, strat_name, sentiments
+        data, strat_name, data_class, sentiments
     )
     cerebro.adddata(pd_data)
     cerebro.broker.setcash(init_cash)

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -66,6 +66,7 @@ def backtest(
     short_max=1.5,
     figsize=(30, 15),
     data_class=None,
+    data_kwargs={},
     **kwargs,
 ):
     """Backtest financial data with a specified trading strategy
@@ -98,6 +99,8 @@ def backtest(
         Symbol to be referenced in the channel notification if not None (default=None)
     data_class : bt.feed.DataBase
         Custom backtrader database to be used as a parent class instead bt.feed. (default=None)
+    data_kwargs : dict
+        Data keyword arguments (empty dict by default)
     {0}
     """
 
@@ -171,7 +174,7 @@ def backtest(
 
     # Initalize and verify data
     pd_data, data, data_format_dict = initalize_data(
-        data, strat_name, data_class, sentiments
+        data, strat_name, symbol, data_class, sentiments, data_kwargs
     )
     cerebro.adddata(pd_data)
     cerebro.broker.setcash(init_cash)

--- a/python/fastquant/backtest/data_prep.py
+++ b/python/fastquant/backtest/data_prep.py
@@ -6,7 +6,7 @@ from pandas.api.types import is_numeric_dtype
 from fastquant.config import DEFAULT_PANDAS
 
 
-def initalize_data(data, strategy_name, data_class=None, sentiments=None):
+def initalize_data(data, strategy_name, symbol=None, data_class=None, sentiments=None, data_kwargs={}):
 
     # Treat `data` as a path if it's a string; otherwise, it's treated as a pandas dataframe
     if isinstance(data, str):
@@ -62,7 +62,7 @@ def initalize_data(data, strategy_name, data_class=None, sentiments=None):
 
             # automatically handle parameter with -1
             # add the parameter to the parameters inherited from the base class
-            params = params_tuple
+            params = params_tuple + (("symbol", symbol),)
     else:
         class CustomData(bt.feeds.PandasData):
             """
@@ -74,10 +74,10 @@ def initalize_data(data, strategy_name, data_class=None, sentiments=None):
 
             # automatically handle parameter with -1
             # add the parameter to the parameters inherited from the base class
-            params = params_tuple
+            params = params_tuple + (("symbol", symbol),)
 
     data_format_dict = tuple_to_dict(params_tuple)
-    pd_data = CustomData(dataname=data, **data_format_dict)
+    pd_data = CustomData(dataname=data, symbol=symbol, **data_format_dict, **data_kwargs)
 
     return pd_data, data, data_format_dict
 

--- a/python/fastquant/backtest/data_prep.py
+++ b/python/fastquant/backtest/data_prep.py
@@ -6,7 +6,7 @@ from pandas.api.types import is_numeric_dtype
 from fastquant.config import DEFAULT_PANDAS
 
 
-def initalize_data(data, strategy_name, sentiments=None):
+def initalize_data(data, strategy_name, data_class=None, sentiments=None):
 
     # Treat `data` as a path if it's a string; otherwise, it's treated as a pandas dataframe
     if isinstance(data, str):
@@ -50,17 +50,31 @@ def initalize_data(data, strategy_name, sentiments=None):
         [col for col, _ in params_tuple if col not in default_cols]
     )
 
-    class CustomData(bt.feeds.PandasData):
-        """
-        Data feed that includes all the columns in the input dataframe
-        """
+    # Use custom data class if input
+    if data_class:
+        class CustomData(data_class):
+            """
+            Data feed that includes all the columns in the input dataframe
+            """
 
-        # Need to make sure that the new lines don't overlap w/ the default lines already in PandasData
-        lines = non_default_numeric_cols
+            # Need to make sure that the new lines don't overlap w/ the default lines already in PandasData
+            lines = non_default_numeric_cols
 
-        # automatically handle parameter with -1
-        # add the parameter to the parameters inherited from the base class
-        params = params_tuple
+            # automatically handle parameter with -1
+            # add the parameter to the parameters inherited from the base class
+            params = params_tuple
+    else:
+        class CustomData(bt.feeds.PandasData):
+            """
+            Data feed that includes all the columns in the input dataframe
+            """
+
+            # Need to make sure that the new lines don't overlap w/ the default lines already in PandasData
+            lines = non_default_numeric_cols
+
+            # automatically handle parameter with -1
+            # add the parameter to the parameters inherited from the base class
+            params = params_tuple
 
     data_format_dict = tuple_to_dict(params_tuple)
     pd_data = CustomData(dataname=data, **data_format_dict)

--- a/python/fastquant/backtest/post_backtest.py
+++ b/python/fastquant/backtest/post_backtest.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
+import backtrader as bt
 
 from fastquant.config import GLOBAL_PARAMS
 
@@ -44,6 +45,7 @@ def analyze_strategies(
         for i, strat in enumerate(stratrun):
             # Get indicator history
             indicators = strat.getindicators()
+            st_dtime = [bt.utils.date.num2date(num) for num in strat.lines.datetime.plot()]
             indicators_dict = {
                 ind.plotlabel()
                 if hasattr(ind, "plotlabel")
@@ -51,7 +53,7 @@ def analyze_strategies(
                 for i, ind in enumerate(indicators)
             }
             indicators_df = pd.DataFrame(indicators_dict)
-            indicators_df.insert(0, "dt", data["datetime"].values)
+            indicators_df.insert(0, "dt", st_dtime)
 
             strat_name = strat_names[i]
             p_raw = strat.p._getkwargs()


### PR DESCRIPTION
There's a new `data_class` argument in `backtest` that allows you to edit the parent class used for `CustomData`#297.

This should allow for greater flexibility on the characterstics of the data object used.

Also included is a fix to allow for dynamic date ranges when extracting historical indicators post backtest #299.