### PR TITLE
Fix #296 by ensuring JFC defaults to PSE

### DIFF
--- a/python/fastquant/data/stocks/stocks.py
+++ b/python/fastquant/data/stocks/stocks.py
@@ -47,7 +47,7 @@ def get_stock_data(
     if source == "yahoo":
         # The query is run on 'yahoo', but if the symbol isn't found, the same query is run on 'phisix'.
         df = get_yahoo_data(symbol, start_date, end_date)
-        if df is None:
+        if df is None or symbol == "JFC":
             format = "c"
             df = get_pse_data(symbol, start_date, end_date, format=format)
 


### PR DESCRIPTION
Quick fix for the JFC issue where yahoo finance has a conflicting symbol. Since JFC is the flagship example, I've decided to default to `get_pse_data` from `get_stock_data` when `JFC` is the ticker.