### PR TITLE
Set get data parameters as attributes to the output dataframe

### DIFF
--- a/python/fastquant/data/crypto/crypto.py
+++ b/python/fastquant/data/crypto/crypto.py
@@ -47,6 +47,10 @@ def get_crypto_data(ticker, start_date, end_date, time_resolution="1d", exchange
         )
         ohlcv_df["dt"] = pd.to_datetime(ohlcv_df["dt"], unit="ms")
         ohlcv_df = ohlcv_df[ohlcv_df.dt <= end_date]
+        # Save input parameters into dataframe
+        ohlcv_df.start_date = start_date
+        ohlcv_df.end_date = end_date
+        ohlcv_df.symbol = ticker
         return ohlcv_df.set_index("dt")
     else:
         raise NotImplementedError(

--- a/python/fastquant/data/stocks/stocks.py
+++ b/python/fastquant/data/stocks/stocks.py
@@ -71,4 +71,9 @@ def get_stock_data(
     if len(missing_columns) > 0:
         print("Missing columns filled w/ NaN:", missing_columns)
 
+    # Save input parameters into dataframe
+    df.start_date = start_date
+    df.end_date = end_date
+    df.symbol = symbol
+
     return df[df_columns]


### PR DESCRIPTION
This will allow us to access the input parameters straight from the dataframe object.

This will be useful at the `backtest` level, so that the `start_date`, `end_date`, and `symbol` doesn't have to be manually input.