### PR TITLE
Add plot arguments

### DIFF
--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -230,6 +230,7 @@ def backtest(
                 plot=plot,
                 verbose=0,
                 sort_by=sort_by,
+                plot_kwargs=plot_kwargs,
                 **optim_params,
             )
         else:

--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -69,6 +69,7 @@ def backtest(
     figsize=(30, 15),
     data_class=None,
     data_kwargs={},
+    plot_kwargs={},
     **kwargs,
 ):
     """Backtest financial data with a specified trading strategy
@@ -109,6 +110,8 @@ def backtest(
         Custom backtrader database to be used as a parent class instead bt.feed. (default=None)
     data_kwargs : dict
         Datafeed keyword arguments (empty dict by default)
+    plot_kwargs : dict
+        Argument for function cerebro.plot() (empty dict by default)
     {0}
     """
 
@@ -230,7 +233,7 @@ def backtest(
                 **optim_params,
             )
         else:
-            plot_results(cerebro, data_format_dict, figsize)
+            plot_results(cerebro, data_format_dict, figsize, **plot_kwargs)
 
     if return_history:
 

--- a/python/fastquant/backtest/post_backtest.py
+++ b/python/fastquant/backtest/post_backtest.py
@@ -205,7 +205,7 @@ def get_optim_metrics_and_params(sorted_metrics_df, sorted_params_df, verbose):
     return optim_params
 
 
-def plot_results(cerebro, data_format_dict, figsize=(30, 15)):
+def plot_results(cerebro, data_format_dict, figsize=(30, 15), **plot_kwargs):
 
     try:
         # This handles the Colab Plotting, Simple Check if we are in Colab
@@ -225,7 +225,7 @@ def plot_results(cerebro, data_format_dict, figsize=(30, 15)):
     plt.style.use("classic")  # ggplot is also fine
     plt.rcParams["figure.figsize"] = figsize
 
-    cerebro.plot(volume=has_volume, iplot=iplot)
+    cerebro.plot(volume=has_volume, iplot=iplot, **plot_kwargs)
 
 
 def print_dict(d, title="", format="inline"):


### PR DESCRIPTION
### Description

Allow users to add arguments to the function `cerebro.plot()` by specifying `plot_kwargs=dictionary_of_items`. I have added the document for this in `backtest` function. But let me know if you need me to add the document for this in any other markdown files

#### Usage
```python
backtest(cfg.strategy.name, df, 
         plot_kwargs={'fmt_x_ticks': '%Y-%b-%d %H:%M', #  Format string for the display of ticks on the x axis
                    'fmt_x_data': '%Y-%b-%d %H:%M'},  # Format string for the display of data points values  
```

### Checklist
 - [x] I am making a pull request from a branch other than the master
 - [x] I have read the CONTRIBUTING.md
 - [x] I have added/edited documentation in a relevant docs/docusaurus markdown file
 - [x] (For new docs, check if not applicable) I have added the id of a new docs md to the docs/docusaurus/sidebars.js file