### PR TITLE
add upperband lowerband to rsi indicator

### DIFF
--- a/python/fastquant/strategies/rsi.py
+++ b/python/fastquant/strategies/rsi.py
@@ -45,7 +45,7 @@ class RSIStrategy(BaseStrategy):
             print("rsi_period :", self.rsi_period)
             print("rsi_upper :", self.rsi_upper)
             print("rsi_lower :", self.rsi_lower)
-        self.rsi = bt.indicators.RelativeStrengthIndex(period=self.rsi_period)
+        self.rsi = bt.indicators.RelativeStrengthIndex(period=self.rsi_period, upperband=self.rsi_upper, lowerband=self.rsi_lower)
 
     def buy_signal(self):
         return self.rsi[0] < self.rsi_lower


### PR DESCRIPTION
### Description

Allow users to customize `upperband` and `lowerband` when using rsi strategy.

### Checklist
 - [x] I am making a pull request from a branch other than master
 - [x] I have read the CONTRIBUTING.md
 - [x] I have added/edited documentation in a relevant docs/docusaurus markdown file
 - [x] (For new docs, check if not applicable) I have added the id of a new docs md to the docs/docusaurus/sidebars.js file