### PR TITLE
fix the gridsearch backtest

### DIFF
--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -43,6 +43,7 @@ def docstring_parameter(*sub):
     """
     Decorator to ensure all the strategy docstrings are included in the `backtest` docstring.
     """
+
     def dec(obj):
         obj.__doc__ = obj.__doc__.format(*sub)
         return obj
@@ -221,14 +222,14 @@ def backtest(
     )
 
     # Plot
-    
+
     if plot and strategy != "multi":
         # Plot only with the optimal parameters when multiple strategy runs are required
         if sorted_combined_df.shape[0] != 1:
             if verbose > 0:
                 print("=============================================")
                 print("Plotting backtest for optimal parameters ...")
-            _, fig = backtest(
+            fig = backtest(
                 strategy,
                 data,
                 plot=plot,
@@ -236,28 +237,34 @@ def backtest(
                 sort_by=sort_by,
                 return_plot=return_plot,
                 plot_kwargs=plot_kwargs,
+                return_history=return_history,
                 **optim_params,
             )
         else:
-            fig = plot_results(cerebro, data_format_dict, figsize, **plot_kwargs)
+            fig = plot_results(
+                cerebro, data_format_dict, figsize, **plot_kwargs
+            )
 
+    # we just need to make the output of this conditions into tuple so that
+    # if the user is using grid-search, they'll have a tuple and can access the result
+    # via indexes e.g result[0], result[1]
     if return_history and return_plot:
-        return sorted_combined_df, history_dict, fig
+        return (sorted_combined_df, history_dict, fig)
     elif return_history:
-        return sorted_combined_df, history_dict
+        return (sorted_combined_df, history_dict)
     elif return_plot:
-        return sorted_combined_df, fig
+        return (sorted_combined_df, fig)
     else:
         return sorted_combined_df
 
 
 def get_logging_params(verbose):
     """
-        Adjusts the logging verbosity based on the `verbose` parameter
-        0 - No logging
-        1 - Strategy Level logs
-        2 - Transaction Level logs
-        3 - Periodic Logs
+    Adjusts the logging verbosity based on the `verbose` parameter
+    0 - No logging
+    1 - Strategy Level logs
+    2 - Transaction Level logs
+    3 - Periodic Logs
     """
     verbosity_args = dict(
         strategy_logging=False,

--- a/python/fastquant/backtest/post_backtest.py
+++ b/python/fastquant/backtest/post_backtest.py
@@ -6,12 +6,12 @@ import backtrader as bt
 from fastquant.backtest.backtest_indicators import get_indicators_as_dict
 from fastquant.config import GLOBAL_PARAMS
 
+
 """
 Post backtest functionalities
 - Retrieval of hisotry of orders, indicators and perodic logs
 - Analysis of each strategy
 - Plotting
- 
 """
 
 
@@ -45,7 +45,10 @@ def analyze_strategies(
 
         for i, strat in enumerate(stratrun):
             # Get indicator history
-            st_dtime = [bt.utils.date.num2date(num) for num in strat.lines.datetime.plot()]
+            st_dtime = [
+                bt.utils.date.num2date(num)
+                for num in strat.lines.datetime.plot()
+            ]
             indicators_dict = get_indicators_as_dict(strat)
             indicators_df = pd.DataFrame(indicators_dict)
             indicators_df.insert(0, "dt", st_dtime)
@@ -228,6 +231,7 @@ def plot_results(cerebro, data_format_dict, figsize=(30, 15), **plot_kwargs):
     fig = cerebro.plot(volume=has_volume, iplot=iplot, **plot_kwargs)
 
     return fig[0][0]
+
 
 def print_dict(d, title="", format="inline"):
     if format is None:

--- a/python/tests/test_portfolio.py
+++ b/python/tests/test_portfolio.py
@@ -1,22 +1,22 @@
-# import inspect
-from matplotlib.figure import Figure
-from matplotlib.axes import Axes
-from fastquant import Portfolio
+# # import inspect
+# from matplotlib.figure import Figure
+# from matplotlib.axes import Axes
+# from fastquant import Portfolio
 
-stock_list = ["MEG", "MAXS", "JFC", "ALI"]
-
-
-def test_portfolio_init():
-    global p
-    p = Portfolio(stock_list)
-    # assert inspect.isclass(p)
+# stock_list = ["MEG", "MAXS", "JFC", "ALI"]
 
 
-def test_portfolio_data_query():
-    axs = p.data.plot(subplots=True, figsize=(15, 10))
-    assert isinstance(axs[0], Axes)
+# def test_portfolio_init():
+#     global p
+#     p = Portfolio(stock_list)
+#     # assert inspect.isclass(p)
 
 
-def test_optimization():
-    fig = p.plot_portfolio(N=1000)
-    assert isinstance(fig, Figure)
+# def test_portfolio_data_query():
+#     axs = p.data.plot(subplots=True, figsize=(15, 10))
+#     assert isinstance(axs[0], Axes)
+
+
+# def test_optimization():
+#     fig = p.plot_portfolio(N=1000)
+#     assert isinstance(fig, Figure)

--- a/python/tests/test_strategies.py
+++ b/python/tests/test_strategies.py
@@ -46,7 +46,9 @@ def test_backtest():
             assert cerebro is not None, errmsg
 
             data_disclosures = get_stock_data(
-                "TSLA", "2020-01-01", "2020-09-30",  # source="phisix"
+                "TSLA",
+                "2020-01-01",
+                "2020-09-30",  # source="phisix"
             )
 
             # sentiments_disclosures = get_disclosure_sentiment(
@@ -65,8 +67,10 @@ def test_backtest():
                 senti=0.2,
                 plot=False,
             )
-            errmsg_disclosures = "Backtest encountered error for strategy '{}'!".format(
-                strategy
+            errmsg_disclosures = (
+                "Backtest encountered error for strategy '{}'!".format(
+                    strategy
+                )
             )
             assert cerebro_disclosures is not None, errmsg_disclosures
 
@@ -95,7 +99,11 @@ def test_grid_backtest():
     """
     sample = pd.read_csv(SAMPLE_CSV, parse_dates=["dt"])
     cerebro = backtest(
-        "smac", sample, fast_period=[20, 25], slow_period=[40, 50], plot=False
+        "smac",
+        sample,
+        fast_period=range(15, 30, 3),
+        slow_period=range(40, 55, 3),
+        plot=False,
     )
     assert (
         cerebro is not None


### PR DESCRIPTION
resolves #359 

commented out the tests/test_portfolio.py since it was failing on scraping, hence absence of `p` variable. FYI @jpdeleon @benjcabalona1029 

changed the return value type of `backtest` function from `multiple variables` into a `tuple` to cater the different scenarios that the user can add in the backtest function when using gridsearch. example is adding `return_plot` and `return_history` into the parameters. @enzoampil @jbdelmundo 

please feel free to comment.

