### PR TITLE
Pull full requested date range in crypto through paged requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ fastquant_0.0.0.9000.tar.gz
 
 # VSCode Workspace files
 *.code-workspace
+.vscode

--- a/python/fastquant/data/crypto/crypto.py
+++ b/python/fastquant/data/crypto/crypto.py
@@ -69,11 +69,13 @@ def get_crypto_data(
                 # We don't have a dataframe yet, so start with this
                 ohlcv_df = current_request_df
             else:
+                # Trim any overlap with the new results
+                ohlcv_df = ohlcv_df[ohlcv_df.dt < current_request_df.dt.min()]
                 # Append the results to what we have so far
                 ohlcv_df = ohlcv_df.append(current_request_df)
 
             # Get the last entry timestamp after we've retrieved (or attempted to) additional records
-            current_request_end_date_epoch = int(ohlcv_df.tail(1).dt.values[0])
+            current_request_end_date_epoch = int(ohlcv_df.dt.max())
 
             if current_request_end_date_epoch <= previous_request_end_date_epoch:
                 # We haven't gained any additional records, so there's no point in further requests

--- a/python/fastquant/data/crypto/crypto.py
+++ b/python/fastquant/data/crypto/crypto.py
@@ -111,7 +111,7 @@ def get_crypto_data(
             ohlcv_df.start_date = start_date
             ohlcv_df.end_date = end_date
             ohlcv_df.symbol = ticker
-            ohlcv_df.set_index("dt")
+            olhcv_df = ohlcv_df.set_index("dt")
             
         return ohlcv_df
     else:

--- a/python/fastquant/data/crypto/crypto.py
+++ b/python/fastquant/data/crypto/crypto.py
@@ -69,6 +69,7 @@ def get_crypto_data(
                 # If we got no results (which happens sometimes, like on binance for ETH/BTC when requesting 2018-02-08)
                 # then step forward to the next day
                 request_start_date_epoch += int(timedelta(days=1).total_seconds()) * 1000
+                previous_request_end_date_epoch = request_start_date_epoch - 1
                 continue
 
             if ohlcv_df is None:

--- a/python/fastquant/data/crypto/crypto.py
+++ b/python/fastquant/data/crypto/crypto.py
@@ -102,15 +102,18 @@ def get_crypto_data(
                 # This request's end date should now be set as current for the next loop
                 previous_request_end_date_epoch = current_request_end_date_epoch
 
-        # Convert the unix timestampe to datetime
-        ohlcv_df["dt"] = pd.to_datetime(ohlcv_df["dt"], unit="ms")
-        # Trim off any records which were returned beyond the end
-        ohlcv_df = ohlcv_df[ohlcv_df.dt <= end_date]
-        # Save input parameters into dataframe
-        ohlcv_df.start_date = start_date
-        ohlcv_df.end_date = end_date
-        ohlcv_df.symbol = ticker
-        return ohlcv_df.set_index("dt")
+        if ohlcv_df is not None:
+            # Convert the unix timestampe to datetime
+            ohlcv_df["dt"] = pd.to_datetime(ohlcv_df["dt"], unit="ms")
+            # Trim off any records which were returned beyond the end
+            ohlcv_df = ohlcv_df[ohlcv_df.dt <= end_date]
+            # Save input parameters into dataframe
+            ohlcv_df.start_date = start_date
+            ohlcv_df.end_date = end_date
+            ohlcv_df.symbol = ticker
+            ohlcv_df.set_index("dt")
+            
+        return ohlcv_df
     else:
         raise NotImplementedError(
             "The exchange " + exchange + " is not yet supported. Available exchanges: "

--- a/python/fastquant/data/crypto/crypto.py
+++ b/python/fastquant/data/crypto/crypto.py
@@ -22,7 +22,9 @@ def unix_time_millis(date):
     return int(dt.timestamp() * 1000)
 
 
-def get_crypto_data(ticker, start_date, end_date, time_resolution="1d", exchange="binance"):
+def get_crypto_data(
+    ticker, start_date, end_date, time_resolution="1d", exchange="binance"
+):
     """
     Get crypto data in OHLCV format
 
@@ -53,9 +55,11 @@ def get_crypto_data(ticker, start_date, end_date, time_resolution="1d", exchange
         # Variable to store our dataframe as we fill it out
         ohlcv_df = None
 
-        while (previous_request_end_date_epoch < end_date_epoch):
+        while previous_request_end_date_epoch < end_date_epoch:
             # Pull the data from the exchange
-            ohlcv_lol = ex.fetch_ohlcv(ticker, time_resolution, since=request_start_date_epoch)
+            ohlcv_lol = ex.fetch_ohlcv(
+                ticker, time_resolution, since=request_start_date_epoch
+            )
             # Convert it to a dataframe
             current_request_df = pd.DataFrame(
                 ohlcv_lol, columns=["dt", "open", "high", "low", "close", "volume"]
@@ -67,7 +71,7 @@ def get_crypto_data(ticker, start_date, end_date, time_resolution="1d", exchange
             else:
                 # Append the results to what we have so far
                 ohlcv_df = ohlcv_df.append(current_request_df)
-            
+
             # Get the last entry timestamp after we've retrieved (or attempted to) additional records
             current_request_end_date_epoch = int(ohlcv_df.tail(1).dt.values[0])
 
@@ -86,7 +90,7 @@ def get_crypto_data(ticker, start_date, end_date, time_resolution="1d", exchange
                 request_start_date_epoch = current_request_end_date_epoch + 1
                 # This request's end date should now be set as current for the next loop
                 previous_request_end_date_epoch = current_request_end_date_epoch
-        
+
         # Convert the unix timestampe to datetime
         ohlcv_df["dt"] = pd.to_datetime(ohlcv_df["dt"], unit="ms")
         # Trim off any records which were returned beyond the end
@@ -98,8 +102,6 @@ def get_crypto_data(ticker, start_date, end_date, time_resolution="1d", exchange
         return ohlcv_df.set_index("dt")
     else:
         raise NotImplementedError(
-            "The exchange "
-            + exchange
-            + " is not yet supported. Available exchanges: "
+            "The exchange " + exchange + " is not yet supported. Available exchanges: "
             ", ".join(CRYPTO_EXCHANGES)
         )

--- a/python/fastquant/data/crypto/crypto.py
+++ b/python/fastquant/data/crypto/crypto.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import pandas as pd
 import ccxt
 
@@ -64,6 +64,12 @@ def get_crypto_data(
             current_request_df = pd.DataFrame(
                 ohlcv_lol, columns=["dt", "open", "high", "low", "close", "volume"]
             )
+
+            if current_request_df.size == 0:
+                # If we got no results (which happens sometimes, like on binance for ETH/BTC when requesting 2018-02-08)
+                # then step forward to the next day
+                request_start_date_epoch += int(timedelta(days=1).total_seconds()) * 1000
+                continue
 
             if ohlcv_df is None:
                 # We don't have a dataframe yet, so start with this

--- a/python/fastquant/data/crypto/crypto.py
+++ b/python/fastquant/data/crypto/crypto.py
@@ -38,14 +38,58 @@ def get_crypto_data(ticker, start_date, end_date, time_resolution="1d", exchange
        market exchanges: 'binance' (default), 'coinbasepro', 'bithumb', 'kraken', 'kucoin', 'bitstamp'
     """
     start_date_epoch = unix_time_millis(start_date)
+    end_date_epoch = unix_time_millis(end_date)
 
     if exchange in CRYPTO_EXCHANGES:
+        # Get the exchange we want to use from ccxt's exchange attributes
         ex = getattr(ccxt, exchange)({"verbose": False})
-        ohlcv_lol = ex.fetch_ohlcv(ticker, time_resolution, since=start_date_epoch)
-        ohlcv_df = pd.DataFrame(
-            ohlcv_lol, columns=["dt", "open", "high", "low", "close", "volume"]
-        )
+
+        # We're going to get data in batches, so want to know what the last record in the previous batch was
+        previous_request_end_date_epoch = start_date_epoch
+
+        # The time we want data from will shift each batch as well
+        request_start_date_epoch = start_date_epoch
+
+        # Variable to store our dataframe as we fill it out
+        ohlcv_df = None
+
+        while (previous_request_end_date_epoch < end_date_epoch):
+            # Pull the data from the exchange
+            ohlcv_lol = ex.fetch_ohlcv(ticker, time_resolution, since=request_start_date_epoch)
+            # Convert it to a dataframe
+            current_request_df = pd.DataFrame(
+                ohlcv_lol, columns=["dt", "open", "high", "low", "close", "volume"]
+            )
+
+            if ohlcv_df is None:
+                # We don't have a dataframe yet, so start with this
+                ohlcv_df = current_request_df
+            else:
+                # Append the results to what we have so far
+                ohlcv_df = ohlcv_df.append(current_request_df)
+            
+            # Get the last entry timestamp after we've retrieved (or attempted to) additional records
+            current_request_end_date_epoch = int(ohlcv_df.tail(1).dt.values[0])
+
+            if current_request_end_date_epoch <= previous_request_end_date_epoch:
+                # We haven't gained any additional records, so there's no point in further requests
+                # Let's mark this for the data end date, mostly so both end_date and end_date_epoch will be
+                # in sync in case someone in future uses them in code futher down and to ensure the loop bails
+                end_date_epoch = current_request_end_date_epoch
+                # Update the actual end date so that the stored value will reflect the actual end
+                end_date = pd.to_datetime(end_date_epoch, unit="ms")
+                # The loop would exit based on the end_date_epoch value, but we'll save that check occuring
+                break
+            else:
+                # We've gained some more records, so let's place another request (unless we're past the end, but our loop will catch that without checking here)
+                # The next request should start a millisecond after this one ended
+                request_start_date_epoch = current_request_end_date_epoch + 1
+                # This request's end date should now be set as current for the next loop
+                previous_request_end_date_epoch = current_request_end_date_epoch
+        
+        # Convert the unix timestampe to datetime
         ohlcv_df["dt"] = pd.to_datetime(ohlcv_df["dt"], unit="ms")
+        # Trim off any records which were returned beyond the end
         ohlcv_df = ohlcv_df[ohlcv_df.dt <= end_date]
         # Save input parameters into dataframe
         ohlcv_df.start_date = start_date

--- a/python/fastquant/data/crypto/crypto.py
+++ b/python/fastquant/data/crypto/crypto.py
@@ -111,7 +111,7 @@ def get_crypto_data(
             ohlcv_df.start_date = start_date
             ohlcv_df.end_date = end_date
             ohlcv_df.symbol = ticker
-            olhcv_df = ohlcv_df.set_index("dt")
+            ohlcv_df = ohlcv_df.set_index("dt")
             
         return ohlcv_df
     else:

--- a/python/fastquant/data/crypto/crypto.py
+++ b/python/fastquant/data/crypto/crypto.py
@@ -69,6 +69,8 @@ def get_crypto_data(
                 # If we got no results (which happens sometimes, like on binance for ETH/BTC when requesting 2018-02-08)
                 # then step forward to the next day
                 request_start_date_epoch += int(timedelta(days=1).total_seconds()) * 1000
+                # Make sure we're at the start of that day
+                request_start_date_epoch = unix_time_millis(pd.to_datetime(request_start_date_epoch, unit="ms").strftime('%Y-%m-%d'))
                 previous_request_end_date_epoch = request_start_date_epoch - 1
                 continue
 


### PR DESCRIPTION
### Description

A quick peruse over the issues didn't seem to have anyone requesting this, but most exchanges only return a limited set of results. 

This change goes through in a result size agnostic manner and requests subsequent results. 

Should there not be results all the way to the end date, that is detected, and the end date for the data set is update to reflect the actual range retrieved.

### Checklist
 - [ ] I am making a pull request from a branch other than master
(Not sure if I'm hitting this one - requesting it from a fork)
 - [x] I have read the CONTRIBUTING.md
 - [ ] I have added/edited documentation in a relevant docs/docusaurus markdown file
(There was nothing in the docs to indicate it didn't return the requested range, so the code just now better reflects the docs as they are.
 - [x] (For new docs, check if not applicable) I have added the id of a new docs md to the docs/docusaurus/sidebars.js file