### PR TITLE
Change matplotlib version to require strictly 3.2.2

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,7 +8,7 @@ chardet>=3.0.4
 croniter>=0.3.35
 idna>=2.8
 lxml>=4.6.2
-matplotlib==3.2.2
+matplotlib>=3.2.2
 networkx>=2.4
 numpy>=1.18.0
 oauthlib>=3.1.0


### PR DESCRIPTION
### Description

With the previous fastquant version, matplotlib would have an error of `ImportError Cannot import name 'warnings' from 'matplotlib.dates` when trying to plot.

This was fixed in the previous PR by [changing matplotlib to 3.2.2.](https://stackoverflow.com/questions/63471764/importerror-cannot-import-name-warnings-from-matplotlib-dates) However, this was committed to be `matplotlib==3.2.2` which may cause issues in pip installs.

This PR changes the matplotlib version to >= 3.2.2. If you get the error stated above, one fix would be to change the version to ==3.2.2.


### Checklist
 - [x] I am making a pull request from a branch other than master
 - [x] I have read the CONTRIBUTING.md