### PR TITLE
Add an option to change the number of cores

### DIFF
--- a/python/fastquant/backtest/backtest.py
+++ b/python/fastquant/backtest/backtest.py
@@ -69,6 +69,7 @@ def backtest(
     return_plot=False,
     channel="",
     symbol="",
+    max_cpus=1,
     allow_short=False,
     short_max=1.5,
     figsize=(30, 15),
@@ -109,6 +110,8 @@ def backtest(
         Channel to be used for notifications - e.g. "slack" (default=None)
     symbol : str
         Symbol to be referenced in the channel notification if not None (default=None)
+    max_cpus : int
+        Determines how many cores will be used. Value of None means that the max cores will be used. This is 1 by default
     allow_short : bool
         Whether to allow short selling, with max set as `short_max` times the portfolio value (default=False)
     short_max : float
@@ -125,7 +128,7 @@ def backtest(
     """
     # Setting initial support for 1 cpu
     # Return the full strategy object to get all run information
-    cerebro = bt.Cerebro(stdstats=False, maxcpus=1, optreturn=False)
+    cerebro = bt.Cerebro(stdstats=False, maxcpus=max_cpus, optreturn=False)
     cerebro.addobserver(bt.observers.Broker)
     cerebro.addobserver(bt.observers.Trades)
     cerebro.addobserver(bt.observers.BuySell)


### PR DESCRIPTION
resolves #370

### Description

There is a feature in backtrader wherein you are able to change the max number of CPUs used to utilize multiprocessing. This has been included as a configurable option in the fastquant backtest wrapper. By default, it will be set to 1. Set it to None to utilize all available cores.

Documentation:
https://www.backtrader.com/blog/posts/2015-07-23-multicore-optimization/multicore-optimization/
https://github.com/mementum/backtrader/blob/0fa63ef4a35dc53cc7320813f8b15480c8f85517/backtrader/cerebro.py#L80

### Checklist
 - [x] I am making a pull request from a branch other than master
 - [x] I have read the CONTRIBUTING.md