### PR TITLE
Adjust pypi version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("python/requirements.txt", "r") as fh:
 
 setuptools.setup(
     name="fastquant",
-    version="0.1.7.3",
+    version="0.1.8.1",
     author="Lorenzo Ampil",
     author_email="lorenzo.ampil@gmail.com",
     description="Bringing data driven investments to the mainstream",


### PR DESCRIPTION
# Adjust pypi version in setup.py

<!---
  The following will not be merged:
    - No issue number/s above, example 'Resolves #231'
    - No documentation for new features
-->


### Description

Currently the version in setup.py does not match the pypi and it is very much delayed. This PR is mainly a aesthetic PR to ensure that the pypi version will match the main repo.

### Checklist
 - [x] I am making a pull request from a branch other than master
 - [x] I have read the CONTRIBUTING.md