### PR TITLE
fix pandas version in requirements.txt file

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -12,7 +12,7 @@ matplotlib>=3.2.2
 networkx>=2.4
 numpy>=1.18.0
 oauthlib>=3.1.0
-pandas>=1.1.5
+pandas>=1.1.5,<=1.5.2
 PySocks>=1.7.1
 python-dateutil>=2.8.1
 pytz>=2019.3


### PR DESCRIPTION
resolves #

<!---
  The following will not be merged:
    - AttributeError: 'DataFrame' object has no attribute 'append' #425
-->


### Description

"I believe the error may be related to your Pandas version. In the requirements.txt file, you've specified 'pandas>=1.1.5.' However, in Pandas 2.0, the 'append' method has been deprecated. You have a few options to resolve this:

You can update the Pandas version to one that supports the 'append' method.
Replace 'append' with '_append' if it's suitable for your code.
Use the 'concat' function instead. Please note that the syntax for 'concat' will change, and you'll need to modify your code to use it like this: 'pd.concat([s1, s2]).'"
so i change the requirements.txt file from pandas>=1.1.5 to pandas>=1.1.5,<=1.5.2


### Checklist
 - [ ] I am making a pull request from a branch other than master
 - [ ] I have read the CONTRIBUTING.md